### PR TITLE
devv5 vignettes + plan to propagate visit_detail_id in v5.5 COST transform

### DIFF
--- a/vignettes/advanced-cost-analysis-v55.Rmd
+++ b/vignettes/advanced-cost-analysis-v55.Rmd
@@ -1,0 +1,123 @@
+---
+title: "Advanced Cost Analysis (CDM v5.5)"
+author: "CostUtilization Team"
+output:
+  rmarkdown::html_vignette:
+    toc: true
+vignette: >
+  %\VignetteIndexEntry{Advanced Cost Analysis (CDM v5.5)}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include=FALSE}
+knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
+```
+
+This vignette demonstrates event filters, visit restrictions, micro-costing, and purrr-driven multi-scenarios.
+
+Setup
+-----
+```{r}
+library(CostUtilization)
+library(DBI)
+library(dplyr)
+library(purrr)
+```
+
+DB and cohort
+-------------
+```{r}
+path <- tempdir()
+db_file <- getEunomiaDuckDb(pathToData = path)
+con <- DBI::dbConnect(duckdb::duckdb(db_file))
+transformCostToCdmV5dot5(con)
+cohort <- read.csv(system.file("testdata","cohort.csv", package = "CostUtilization"))
+DBI::dbWriteTable(con, "cohort", cohort, overwrite = TRUE)
+```
+
+Event filters and visit restriction
+-----------------------------------
+```{r}
+filters <- list(
+  list(name = "Diabetes Dx", domain = "Condition", conceptIds = c(201820L, 201826L)),
+  list(name = "Diabetes Meds", domain = "Drug", conceptIds = c(1503297L, 1502826L))
+)
+
+settings <- createCostOfCareSettings(
+  anchorCol = "cohort_start_date",
+  startOffsetDays = -180L,
+  endOffsetDays = 180L,
+  eventFilters = filters,
+  restrictVisitConceptIds = 9201L, # inpatient
+  costConceptId = 31985L # total_cost
+)
+
+res <- calculateCostOfCare(
+  connection = con,
+  cdmDatabaseSchema = "main",
+  cohortDatabaseSchema = "main",
+  cohortTable = "cohort",
+  cohortId = 1,
+  costOfCareSettings = settings,
+  verbose = TRUE
+)
+res$results
+```
+
+Micro-costing
+-------------
+```{r}
+settings_micro <- createCostOfCareSettings(
+  anchorCol = "cohort_start_date",
+  startOffsetDays = 0L,
+  endOffsetDays = 365L,
+  eventFilters = list(list(name = "Procedures", domain = "Procedure", conceptIds = c(40489223L, 4187094L))),
+  microCosting = TRUE,
+  primaryEventFilterName = "Procedures",
+  costConceptId = 31973L
+)
+
+res_micro <- calculateCostOfCare(
+  connection = con,
+  cdmDatabaseSchema = "main",
+  cohortDatabaseSchema = "main",
+  cohortTable = "cohort",
+  cohortId = 1,
+  costOfCareSettings = settings_micro
+)
+res_micro$results
+```
+
+Multiple scenarios with purrr
+-----------------------------
+```{r}
+scenarios <- tibble::tibble(
+  label = c("charge","paid_payer","paid_patient"),
+  concept = c(31973L, 31980L, 31981L)
+)
+
+multi <- scenarios %>%
+  pmap_dfr(function(label, concept){
+    s <- createCostOfCareSettings(costConceptId = concept)
+    out <- calculateCostOfCare(
+      connection = con,
+      cdmDatabaseSchema = "main",
+      cohortDatabaseSchema = "main",
+      cohortTable = "cohort",
+      cohortId = 1,
+      costOfCareSettings = s,
+      verbose = FALSE
+    )
+    out$results %>% dplyr::mutate(costType = label)
+  })
+
+multi
+```
+
+Cleanup
+-------
+```{r}
+DBI::dbDisconnect(con, shutdown = TRUE)
+unlink(db_file)
+```

--- a/vignettes/eunomia-setup-v55.Rmd
+++ b/vignettes/eunomia-setup-v55.Rmd
@@ -24,7 +24,7 @@ knitr::opts_chunk$set(
 
 # Introduction
 
-This vignette provides detailed instructions for setting up the Eunomia synthetic dataset with CDM v5.5 cost data for testing and development with the `CostUtilization` package. Eunomia provides a lightweight, self-contained OMOP CDM database that's perfect for learning, testing, and development.
+This vignette provides comprehensive instructions for setting up the Eunomia synthetic dataset with CDM v5.5 cost data for testing and development with the `CostUtilization` package. Eunomia provides a lightweight, self-contained OMOP CDM database that's perfect for learning, testing, and development.
 
 ## What is Eunomia?
 
@@ -52,23 +52,35 @@ library(DBI)
 library(duckdb)
 library(dplyr)
 library(rlang)
+library(tibble)
+library(purrr)
 ```
+
+# Core Functions Overview
+
+The CostUtilization package provides four key functions for setting up Eunomia with cost data:
+
+1. **`getEunomiaDuckDb()`** - Downloads and creates base Eunomia database
+2. **`injectCostData()`** - Adds synthetic cost records to the database
+3. **`injectVisitDetailsData()`** - Creates visit detail records for micro-costing
+4. **`transformCostToCdmV5dot5()`** - Complete transformation including all steps above
 
 # Step-by-Step Setup
 
-## Step 1: Download and Create Eunomia Database
+## Step 1: Download and Create Base Eunomia Database
 
 The `getEunomiaDuckDb()` function handles downloading and setting up the Eunomia dataset:
 
 ```{r download-eunomia}
 # Set up data directory (optional - uses temp by default)
 data_dir <- file.path(tempdir(), "eunomia_data")
-dir.create(data_dir, showWarnings = FALSE)
+dir.create(data_dir, showWarnings = FALSE, recursive = TRUE)
 
 # Download and create Eunomia DuckDB database
 databaseFile <- getEunomiaDuckDb(
-  databaseFile = file.path(tempdir(), "eunomia_v55.duckdb"),
-  pathToData = data_dir
+  databaseFile = file.path(tempdir(), "eunomia_base.duckdb"),
+  pathToData = data_dir,
+  overwrite = TRUE
 )
 
 # Connect to the database
@@ -76,8 +88,36 @@ connection <- DBI::dbConnect(duckdb::duckdb(databaseFile))
 
 # Verify basic CDM tables exist
 tables <- DBI::dbListTables(connection)
+cdm_tables <- sort(tables[!grepl("^(sqlite_|cdm_)", tables)])
 cat("Available CDM tables:\n")
-cat(paste(sort(tables), collapse = ", "))
+cat(paste(cdm_tables, collapse = ", "))
+```
+
+### Function Parameters and Options
+
+```{r getEunomiaDuckDb-options}
+# Basic usage with defaults
+databaseFile1 <- getEunomiaDuckDb()
+
+# Custom database location
+databaseFile2 <- getEunomiaDuckDb(
+  databaseFile = "/path/to/my/eunomia.duckdb"
+)
+
+# Custom data directory for downloads
+databaseFile3 <- getEunomiaDuckDb(
+  pathToData = "/path/to/eunomia/archives"
+)
+
+# Overwrite existing database
+databaseFile4 <- getEunomiaDuckDb(
+  databaseFile = "eunomia.duckdb",
+  overwrite = TRUE
+)
+
+# Using environment variable for consistent paths
+Sys.setenv(EUNOMIA_DATA_FOLDER = data_dir)
+databaseFile5 <- getEunomiaDuckDb()  # Will use EUNOMIA_DATA_FOLDER
 ```
 
 ## Step 2: Examine Base CDM Data
@@ -94,7 +134,8 @@ obs_periods <- DBI::dbGetQuery(connection, "
   SELECT 
     MIN(observation_period_start_date) as earliest_date,
     MAX(observation_period_end_date) as latest_date,
-    COUNT(*) as n_periods
+    COUNT(*) as n_periods,
+    COUNT(DISTINCT person_id) as n_persons
   FROM observation_period
 ")
 print(obs_periods)
@@ -104,19 +145,23 @@ visit_summary <- DBI::dbGetQuery(connection, "
   SELECT 
     visit_concept_id,
     COUNT(*) as n_visits,
-    COUNT(DISTINCT person_id) as n_persons
+    COUNT(DISTINCT person_id) as n_persons,
+    MIN(visit_start_date) as earliest_visit,
+    MAX(visit_start_date) as latest_visit
   FROM visit_occurrence 
   GROUP BY visit_concept_id
   ORDER BY n_visits DESC
 ")
 print(visit_summary)
 
-# Check clinical events
+# Check clinical events by domain
 event_summary <- DBI::dbGetQuery(connection, "
   SELECT 
     'Conditions' as domain,
     COUNT(*) as n_events,
-    COUNT(DISTINCT person_id) as n_persons
+    COUNT(DISTINCT person_id) as n_persons,
+    MIN(condition_start_date) as earliest_date,
+    MAX(condition_start_date) as latest_date
   FROM condition_occurrence
   
   UNION ALL
@@ -124,7 +169,9 @@ event_summary <- DBI::dbGetQuery(connection, "
   SELECT 
     'Drug Exposures' as domain,
     COUNT(*) as n_events,
-    COUNT(DISTINCT person_id) as n_persons  
+    COUNT(DISTINCT person_id) as n_persons,  
+    MIN(drug_exposure_start_date) as earliest_date,
+    MAX(drug_exposure_start_date) as latest_date
   FROM drug_exposure
   
   UNION ALL
@@ -132,7 +179,9 @@ event_summary <- DBI::dbGetQuery(connection, "
   SELECT 
     'Procedures' as domain,
     COUNT(*) as n_events,
-    COUNT(DISTINCT person_id) as n_persons
+    COUNT(DISTINCT person_id) as n_persons,
+    MIN(procedure_date) as earliest_date,
+    MAX(procedure_date) as latest_date
   FROM procedure_occurrence
   
   UNION ALL
@@ -140,58 +189,352 @@ event_summary <- DBI::dbGetQuery(connection, "
   SELECT 
     'Measurements' as domain,
     COUNT(*) as n_events,
-    COUNT(DISTINCT person_id) as n_persons
+    COUNT(DISTINCT person_id) as n_persons,
+    MIN(measurement_date) as earliest_date,
+    MAX(measurement_date) as latest_date
   FROM measurement
 ")
 print(event_summary)
+
+# Check vocabularies
+vocab_summary <- DBI::dbGetQuery(connection, "
+  SELECT 
+    vocabulary_id,
+    vocabulary_name,
+    COUNT(*) as n_concepts
+  FROM concept
+  WHERE invalid_reason IS NULL
+  GROUP BY vocabulary_id, vocabulary_name
+  ORDER BY n_concepts DESC
+  LIMIT 10
+")
+print(vocab_summary)
 ```
 
-## Step 3: Transform to CDM v5.5 with Cost Data
+## Step 3: Inject Synthetic Cost Data
 
-The `transformCostToCdmV5dot5()` function performs several operations:
+The `injectCostData()` function adds synthetic cost records in CDM v5.3 wide format:
 
-1. **Injects synthetic cost data** in wide format (v5.3 style)
-2. **Creates payer plan periods** with realistic insurance coverage
-3. **Populates visit_detail table** from clinical events
-4. **Transforms cost data** to CDM v5.5 long format
-
-```{r transform-v55}
-# Transform to CDM v5.5 with cost data
-connection <- transformCostToCdmV5dot5(
+```{r inject-cost-data}
+# Inject cost data with default settings
+connection <- injectCostData(
   connection = connection,
   cdmDatabaseSchema = "main"
 )
 
-# Verify new tables were created
-new_tables <- DBI::dbListTables(connection)
-cost_tables <- new_tables[grepl("cost|payer|visit_detail", new_tables, ignore.case = TRUE)]
-cat("Cost-related tables:\n")
-cat(paste(sort(cost_tables), collapse = ", "), "\n")
+# Check if cost data was added to clinical tables
+cost_columns_check <- DBI::dbGetQuery(connection, "
+  PRAGMA table_info(visit_occurrence)
+")
+
+# Look for cost-related columns
+cost_cols <- cost_columns_check$name[grepl("cost|paid", cost_columns_check$name, ignore.case = TRUE)]
+cat("Cost columns added to visit_occurrence:\n")
+cat(paste(cost_cols, collapse = ", "), "\n")
+
+# Check cost data distribution in visit_occurrence
+visit_cost_summary <- DBI::dbGetQuery(connection, "
+  SELECT 
+    COUNT(*) as total_visits,
+    COUNT(total_paid) as visits_with_total_paid,
+    COUNT(paid_by_payer) as visits_with_payer_paid,
+    COUNT(paid_by_patient) as visits_with_patient_paid,
+    ROUND(AVG(total_paid), 2) as avg_total_paid,
+    ROUND(AVG(paid_by_payer), 2) as avg_payer_paid,
+    ROUND(AVG(paid_by_patient), 2) as avg_patient_paid
+  FROM visit_occurrence
+  WHERE total_paid IS NOT NULL
+")
+print(visit_cost_summary)
+
+# Check cost data in drug_exposure table
+drug_cost_summary <- DBI::dbGetQuery(connection, "
+  SELECT 
+    COUNT(*) as total_drugs,
+    COUNT(total_paid) as drugs_with_cost,
+    ROUND(AVG(total_paid), 2) as avg_drug_cost,
+    ROUND(MIN(total_paid), 2) as min_drug_cost,
+    ROUND(MAX(total_paid), 2) as max_drug_cost
+  FROM drug_exposure
+  WHERE total_paid IS NOT NULL
+")
+print(drug_cost_summary)
 ```
 
-## Step 4: Examine Generated Cost Data
+### Advanced Cost Data Injection Options
 
-Let's explore the synthetic cost data that was generated:
+```{r inject-cost-advanced}
+# Disconnect and reconnect to clean state for demonstration
+DBI::dbDisconnect(connection, shutdown = TRUE)
+connection <- DBI::dbConnect(duckdb::duckdb(databaseFile))
 
-```{r examine-cost}
-# Check payer plan periods
-payer_summary <- DBI::dbGetQuery(connection, "
+# Inject cost data with custom seed for reproducible results
+connection <- injectCostData(
+  connection = connection,
+  cdmDatabaseSchema = "main",
+  seed = 12345  # For reproducible synthetic cost data
+)
+
+# Alternative: inject to specific schema (if using multi-schema setup)
+# connection <- injectCostData(
+#   connection = connection,
+#   cdmDatabaseSchema = "cdm_eunomia",
+#   seed = 12345
+# )
+
+# Verify reproducibility with same seed
+connection2 <- DBI::dbConnect(duckdb::duckdb(":memory:"))
+# Would need to recreate base tables first, then:
+# connection2 <- injectCostData(connection2, "main", seed = 12345)
+# Results should be identical
+
+# Check specific cost distributions
+cost_distribution <- DBI::dbGetQuery(connection, "
   SELECT 
-    payer_source_value,
-    plan_source_value,
-    COUNT(*) as n_periods,
-    COUNT(DISTINCT person_id) as n_persons
-  FROM payer_plan_period
-  GROUP BY payer_source_value, plan_source_value
-  ORDER BY n_periods DESC
+    'Visit Occurrence' as table_name,
+    COUNT(*) as n_records,
+    COUNT(total_paid) as n_with_cost,
+    ROUND(AVG(total_paid), 2) as mean_cost,
+    ROUND(PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY total_paid), 2) as median_cost,
+    ROUND(STDDEV(total_paid), 2) as sd_cost
+  FROM visit_occurrence
+  WHERE total_paid IS NOT NULL
+  
+  UNION ALL
+  
+  SELECT 
+    'Drug Exposure' as table_name,
+    COUNT(*) as n_records,
+    COUNT(total_paid) as n_with_cost,
+    ROUND(AVG(total_paid), 2) as mean_cost,
+    ROUND(PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY total_paid), 2) as median_cost,
+    ROUND(STDDEV(total_paid), 2) as sd_cost
+  FROM drug_exposure
+  WHERE total_paid IS NOT NULL
+  
+  UNION ALL
+  
+  SELECT 
+    'Procedure Occurrence' as table_name,
+    COUNT(*) as n_records,
+    COUNT(total_paid) as n_with_cost,
+    ROUND(AVG(total_paid), 2) as mean_cost,
+    ROUND(PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY total_paid), 2) as median_cost,
+    ROUND(STDDEV(total_paid), 2) as sd_cost
+  FROM procedure_occurrence
+  WHERE total_paid IS NOT NULL
 ")
-print(payer_summary)
+print(cost_distribution)
+```
 
+## Step 4: Inject Visit Details Data
+
+The `injectVisitDetailsData()` function creates visit detail records for micro-costing analysis:
+
+```{r inject-visit-details}
+# Inject visit details data
+connection <- injectVisitDetailsData(
+  connection = connection,
+  cdmDatabaseSchema = "main"
+)
+
+# Verify visit_detail table was created
+visit_detail_exists <- DBI::dbExistsTable(connection, "visit_detail")
+cat("Visit detail table created:", visit_detail_exists, "\n")
+
+# Examine visit detail structure
+visit_detail_structure <- DBI::dbGetQuery(connection, "
+  SELECT * FROM visit_detail LIMIT 3
+")
+print(visit_detail_structure)
+
+# Visit detail summary statistics
+visit_detail_summary <- DBI::dbGetQuery(connection, "
+  SELECT 
+    COUNT(*) as n_visit_details,
+    COUNT(DISTINCT person_id) as n_persons,
+    COUNT(DISTINCT visit_occurrence_id) as n_visits,
+    COUNT(DISTINCT visit_detail_concept_id) as n_detail_concepts,
+    MIN(visit_detail_start_date) as earliest_detail,
+    MAX(visit_detail_start_date) as latest_detail
+  FROM visit_detail
+")
+print(visit_detail_summary)
+
+# Visit detail concept distribution
+visit_detail_concepts <- DBI::dbGetQuery(connection, "
+  SELECT 
+    visit_detail_concept_id,
+    COUNT(*) as n_details,
+    COUNT(DISTINCT person_id) as n_persons,
+    COUNT(DISTINCT visit_occurrence_id) as n_visits
+  FROM visit_detail
+  GROUP BY visit_detail_concept_id
+  ORDER BY n_details DESC
+")
+print(visit_detail_concepts)
+
+# Relationship between visits and visit details
+visit_detail_relationship <- DBI::dbGetQuery(connection, "
+  SELECT 
+    vo.visit_concept_id,
+    COUNT(DISTINCT vo.visit_occurrence_id) as n_visits,
+    COUNT(vd.visit_detail_id) as n_visit_details,
+    ROUND(CAST(COUNT(vd.visit_detail_id) AS FLOAT) / COUNT(DISTINCT vo.visit_occurrence_id), 2) as avg_details_per_visit
+  FROM visit_occurrence vo
+  LEFT JOIN visit_detail vd ON vo.visit_occurrence_id = vd.visit_occurrence_id
+  GROUP BY vo.visit_concept_id
+  ORDER BY n_visits DESC
+")
+print(visit_detail_relationship)
+```
+
+### Advanced Visit Details Options
+
+```{r inject-visit-details-advanced}
+# The function automatically creates visit details based on:
+# 1. Clinical events during visits (conditions, procedures, drugs, measurements)
+# 2. Visit type and duration
+# 3. Realistic care patterns
+
+# Check how clinical events map to visit details
+event_mapping <- DBI::dbGetQuery(connection, "
+  SELECT 
+    'Condition -> Visit Detail' as mapping_type,
+    COUNT(DISTINCT co.condition_occurrence_id) as n_source_events,
+    COUNT(DISTINCT vd.visit_detail_id) as n_visit_details
+  FROM condition_occurrence co
+  JOIN visit_detail vd ON co.visit_occurrence_id = vd.visit_occurrence_id
+    AND co.condition_start_date = vd.visit_detail_start_date
+  
+  UNION ALL
+  
+  SELECT 
+    'Procedure -> Visit Detail' as mapping_type,
+    COUNT(DISTINCT po.procedure_occurrence_id) as n_source_events,
+    COUNT(DISTINCT vd.visit_detail_id) as n_visit_details
+  FROM procedure_occurrence po
+  JOIN visit_detail vd ON po.visit_occurrence_id = vd.visit_occurrence_id
+    AND po.procedure_date = vd.visit_detail_start_date
+  
+  UNION ALL
+  
+  SELECT 
+    'Drug -> Visit Detail' as mapping_type,
+    COUNT(DISTINCT de.drug_exposure_id) as n_source_events,
+    COUNT(DISTINCT vd.visit_detail_id) as n_visit_details
+  FROM drug_exposure de
+  JOIN visit_detail vd ON de.visit_occurrence_id = vd.visit_occurrence_id
+    AND de.drug_exposure_start_date = vd.visit_detail_start_date
+")
+print(event_mapping)
+
+# Check visit detail hierarchy (parent-child relationships)
+visit_detail_hierarchy <- DBI::dbGetQuery(connection, "
+  SELECT 
+    COUNT(*) as total_visit_details,
+    COUNT(visit_detail_parent_id) as n_with_parent,
+    COUNT(CASE WHEN visit_detail_parent_id IS NULL THEN 1 END) as n_root_details
+  FROM visit_detail
+")
+print(visit_detail_hierarchy)
+```
+
+## Step 5: Add Payer Plan Periods
+
+```{r add-payer-plans}
+# Check if payer plan periods were created (part of cost injection)
+payer_exists <- DBI::dbExistsTable(connection, "payer_plan_period")
+cat("Payer plan period table exists:", payer_exists, "\n")
+
+if (payer_exists) {
+  # Examine payer plan structure
+  payer_structure <- DBI::dbGetQuery(connection, "
+    SELECT * FROM payer_plan_period LIMIT 3
+  ")
+  print(payer_structure)
+  
+  # Payer plan summary
+  payer_summary <- DBI::dbGetQuery(connection, "
+    SELECT 
+      payer_source_value,
+      plan_source_value,
+      COUNT(*) as n_periods,
+      COUNT(DISTINCT person_id) as n_persons,
+      MIN(payer_plan_period_start_date) as earliest_coverage,
+      MAX(payer_plan_period_end_date) as latest_coverage,
+      ROUND(AVG(JULIANDAY(payer_plan_period_end_date) - JULIANDAY(payer_plan_period_start_date)), 0) as avg_coverage_days
+    FROM payer_plan_period
+    GROUP BY payer_source_value, plan_source_value
+    ORDER BY n_periods DESC
+  ")
+  print(payer_summary)
+  
+  # Coverage overlap with observation periods
+  coverage_overlap <- DBI::dbGetQuery(connection, "
+    SELECT 
+      COUNT(DISTINCT p.person_id) as n_persons_total,
+      COUNT(DISTINCT ppp.person_id) as n_persons_with_coverage,
+      ROUND(CAST(COUNT(DISTINCT ppp.person_id) AS FLOAT) / COUNT(DISTINCT p.person_id) * 100, 1) as coverage_percentage
+    FROM person p
+    LEFT JOIN payer_plan_period ppp ON p.person_id = ppp.person_id
+  ")
+  print(coverage_overlap)
+}
+```
+
+## Step 6: Complete CDM v5.5 Transformation
+
+The `transformCostToCdmV5dot5()` function performs all steps above plus converts to CDM v5.5 long format:
+
+```{r transform-v55-complete}
+# Start fresh for complete transformation demonstration
+DBI::dbDisconnect(connection, shutdown = TRUE)
+
+# Create new database for complete transformation
+databaseFile_v55 <- file.path(tempdir(), "eunomia_v55_complete.duckdb")
+databaseFile_v55 <- getEunomiaDuckDb(
+  databaseFile = databaseFile_v55,
+  pathToData = data_dir,
+  overwrite = TRUE
+)
+
+connection <- DBI::dbConnect(duckdb::duckdb(databaseFile_v55))
+
+# Apply complete transformation to CDM v5.5 with cost data
+connection <- transformCostToCdmV5dot5(
+  connection = connection,
+  cdmDatabaseSchema = "main",
+  seed = 12345  # For reproducible results
+)
+
+# Verify all new tables were created
+all_tables <- DBI::dbListTables(connection)
+new_tables <- c("cost", "payer_plan_period", "visit_detail")
+new_tables_exist <- new_tables %in% all_tables
+
+cat("New CDM v5.5 tables created:\n")
+for (i in seq_along(new_tables)) {
+  cat(sprintf("  %s: %s\n", new_tables[i], ifelse(new_tables_exist[i], "✓", "✗")))
+}
+```
+
+### Examine CDM v5.5 Cost Table Structure
+
+```{r examine-v55-cost}
 # Check cost table structure (CDM v5.5 long format)
 cost_structure <- DBI::dbGetQuery(connection, "
-  SELECT * FROM cost LIMIT 5
+  PRAGMA table_info(cost)
 ")
 print(cost_structure)
+
+# Sample cost records
+cost_sample <- DBI::dbGetQuery(connection, "
+  SELECT * FROM cost 
+  ORDER BY person_id, visit_occurrence_id, cost_concept_id
+  LIMIT 10
+")
+print(cost_sample)
 
 # Cost concept distribution
 cost_concepts <- DBI::dbGetQuery(connection, "
@@ -199,7 +542,10 @@ cost_concepts <- DBI::dbGetQuery(connection, "
     cost_concept_id,
     cost_source_value,
     COUNT(*) as n_records,
+    COUNT(DISTINCT person_id) as n_persons,
     ROUND(AVG(cost), 2) as avg_cost,
+    ROUND(MIN(cost), 2) as min_cost,
+    ROUND(MAX(cost), 2) as max_cost,
     ROUND(SUM(cost), 2) as total_cost
   FROM cost
   GROUP BY cost_concept_id, cost_source_value
@@ -207,27 +553,165 @@ cost_concepts <- DBI::dbGetQuery(connection, "
 ")
 print(cost_concepts)
 
-# Visit detail summary
-visit_detail_summary <- DBI::dbGetQuery(connection, "
+# Cost by domain
+cost_by_domain <- DBI::dbGetQuery(connection, "
   SELECT 
-    COUNT(*) as n_visit_details,
+    CASE 
+      WHEN visit_occurrence_id IS NOT NULL AND visit_detail_id IS NULL THEN 'Visit Level'
+      WHEN visit_detail_id IS NOT NULL THEN 'Visit Detail Level'
+      WHEN drug_exposure_id IS NOT NULL THEN 'Drug Exposure'
+      WHEN procedure_occurrence_id IS NOT NULL THEN 'Procedure'
+      WHEN device_exposure_id IS NOT NULL THEN 'Device'
+      WHEN measurement_id IS NOT NULL THEN 'Measurement'
+      ELSE 'Other'
+    END as cost_domain,
+    COUNT(*) as n_records,
     COUNT(DISTINCT person_id) as n_persons,
-    COUNT(DISTINCT visit_occurrence_id) as n_visits
-  FROM visit_detail
+    ROUND(SUM(cost), 2) as total_cost,
+    ROUND(AVG(cost), 2) as avg_cost
+  FROM cost
+  GROUP BY cost_domain
+  ORDER BY total_cost DESC
 ")
-print(visit_detail_summary)
+print(cost_by_domain)
 ```
 
-## Step 5: Create Sample Cohort
+## Step 7: Data Quality Validation
 
-For testing, let's create a simple cohort:
+```{r data-quality-validation}
+# Comprehensive data quality checks
+validation_checks <- list()
 
-```{r create-cohort}
-# Create a simple cohort table for testing
-# This creates a cohort of patients with any condition occurrence
-cohort_sql <- "
+# 1. Referential integrity
+validation_checks$referential_integrity <- DBI::dbGetQuery(connection, "
+  SELECT 
+    'Cost -> Person' as check_name,
+    COUNT(*) as total_records,
+    COUNT(DISTINCT c.person_id) as unique_persons,
+    COUNT(DISTINCT p.person_id) as valid_persons,
+    CASE WHEN COUNT(DISTINCT c.person_id) = COUNT(DISTINCT p.person_id) 
+         THEN 'PASS' ELSE 'FAIL' END as result
+  FROM cost c
+  LEFT JOIN person p ON c.person_id = p.person_id
+  
+  UNION ALL
+  
+  SELECT 
+    'Cost -> Visit' as check_name,
+    COUNT(*) as total_records,
+    COUNT(c.visit_occurrence_id) as records_with_visit,
+    COUNT(v.visit_occurrence_id) as valid_visits,
+    CASE WHEN COUNT(c.visit_occurrence_id) = COUNT(v.visit_occurrence_id) 
+         THEN 'PASS' ELSE 'FAIL' END as result
+  FROM cost c
+  LEFT JOIN visit_occurrence v ON c.visit_occurrence_id = v.visit_occurrence_id
+  WHERE c.visit_occurrence_id IS NOT NULL
+  
+  UNION ALL
+  
+  SELECT 
+    'Visit Detail -> Visit' as check_name,
+    COUNT(*) as total_records,
+    COUNT(vd.visit_occurrence_id) as records_with_visit,
+    COUNT(v.visit_occurrence_id) as valid_visits,
+    CASE WHEN COUNT(vd.visit_occurrence_id) = COUNT(v.visit_occurrence_id) 
+         THEN 'PASS' ELSE 'FAIL' END as result
+  FROM visit_detail vd
+  LEFT JOIN visit_occurrence v ON vd.visit_occurrence_id = v.visit_occurrence_id
+")
+
+print("=== REFERENTIAL INTEGRITY CHECKS ===")
+print(validation_checks$referential_integrity)
+
+# 2. Data completeness
+validation_checks$completeness <- DBI::dbGetQuery(connection, "
+  SELECT 
+    'Cost Records' as metric,
+    COUNT(*) as total_count,
+    COUNT(cost) as non_null_cost,
+    COUNT(cost_concept_id) as non_null_concept,
+    ROUND(CAST(COUNT(cost) AS FLOAT) / COUNT(*) * 100, 1) as completeness_pct
+  FROM cost
+  
+  UNION ALL
+  
+  SELECT 
+    'Payer Periods' as metric,
+    COUNT(*) as total_count,
+    COUNT(payer_source_value) as non_null_payer,
+    COUNT(plan_source_value) as non_null_plan,
+    ROUND(CAST(COUNT(payer_source_value) AS FLOAT) / COUNT(*) * 100, 1) as completeness_pct
+  FROM payer_plan_period
+  
+  UNION ALL
+  
+  SELECT 
+    'Visit Details' as metric,
+    COUNT(*) as total_count,
+    COUNT(visit_detail_concept_id) as non_null_concept,
+    COUNT(visit_detail_start_date) as non_null_start_date,
+    ROUND(CAST(COUNT(visit_detail_concept_id) AS FLOAT) / COUNT(*) * 100, 1) as completeness_pct
+  FROM visit_detail
+")
+
+print("=== DATA COMPLETENESS CHECKS ===")
+print(validation_checks$completeness)
+
+# 3. Date consistency
+validation_checks$date_consistency <- DBI::dbGetQuery(connection, "
+  SELECT 
+    'Visit Detail Dates' as check_name,
+    COUNT(*) as total_records,
+    COUNT(CASE WHEN visit_detail_start_date <= visit_detail_end_date THEN 1 END) as valid_date_order,
+    COUNT(CASE WHEN visit_detail_start_date <= visit_detail_end_date THEN 1 END) * 100.0 / COUNT(*) as pass_rate_pct
+  FROM visit_detail
+  WHERE visit_detail_end_date IS NOT NULL
+  
+  UNION ALL
+  
+  SELECT 
+    'Payer Period Dates' as check_name,
+    COUNT(*) as total_records,
+    COUNT(CASE WHEN payer_plan_period_start_date <= payer_plan_period_end_date THEN 1 END) as valid_date_order,
+    COUNT(CASE WHEN payer_plan_period_start_date <= payer_plan_period_end_date THEN 1 END) * 100.0 / COUNT(*) as pass_rate_pct
+  FROM payer_plan_period
+  WHERE payer_plan_period_end_date IS NOT NULL
+")
+
+print("=== DATE CONSISTENCY CHECKS ===")
+print(validation_checks$date_consistency)
+
+# 4. Cost value ranges
+validation_checks$cost_ranges <- DBI::dbGetQuery(connection, "
+  SELECT 
+    cost_concept_id,
+    cost_source_value,
+    COUNT(*) as n_records,
+    ROUND(MIN(cost), 2) as min_cost,
+    ROUND(MAX(cost), 2) as max_cost,
+    ROUND(AVG(cost), 2) as avg_cost,
+    COUNT(CASE WHEN cost < 0 THEN 1 END) as negative_costs,
+    COUNT(CASE WHEN cost = 0 THEN 1 END) as zero_costs,
+    COUNT(CASE WHEN cost > 100000 THEN 1 END) as high_costs
+  FROM cost
+  GROUP BY cost_concept_id, cost_source_value
+  ORDER BY cost_concept_id
+")
+
+print("=== COST VALUE RANGE CHECKS ===")
+print(validation_checks$cost_ranges)
+```
+
+# Testing Cost Analysis Functions
+
+## Create Sample Cohorts
+
+```{r create-cohorts}
+# Create multiple cohorts for comprehensive testing
+cohort_creation_sql <- "
   CREATE TABLE cohort AS
-  SELECT DISTINCT
+  -- Cohort 1: Patients with any condition
+  SELECT 
     1 as cohort_definition_id,
     person_id as subject_id,
     MIN(condition_start_date) as cohort_start_date,
@@ -237,423 +721,68 @@ cohort_sql <- "
   WHERE condition_start_date >= observation_period_start_date
     AND condition_start_date <= observation_period_end_date
   GROUP BY person_id, observation_period_end_date
-  HAVING COUNT(*) >= 2  -- At least 2 conditions
+  HAVING COUNT(*) >= 1
+  
+  UNION ALL
+  
+  -- Cohort 2: Patients with diabetes (Type 2 diabetes mellitus - 201826)
+  SELECT 
+    2 as cohort_definition_id,
+    person_id as subject_id,
+    MIN(condition_start_date) as cohort_start_date,
+    observation_period_end_date as cohort_end_date
+  FROM condition_occurrence co
+  JOIN observation_period op ON op.person_id = co.person_id
+  WHERE condition_concept_id IN (201826, 4193704)  -- T2DM concepts
+    AND condition_start_date >= observation_period_start_date
+    AND condition_start_date <= observation_period_end_date
+  GROUP BY person_id, observation_period_end_date
+  
+  UNION ALL
+  
+  -- Cohort 3: Patients with any drug exposure
+  SELECT 
+    3 as cohort_definition_id,
+    person_id as subject_id,
+    MIN(drug_exposure_start_date) as cohort_start_date,
+    observation_period_end_date as cohort_end_date
+  FROM drug_exposure de
+  JOIN observation_period op ON op.person_id = de.person_id
+  WHERE drug_exposure_start_date >= observation_period_start_date
+    AND drug_exposure_start_date <= observation_period_end_date
+  GROUP BY person_id, observation_period_end_date
 "
 
-DBI::dbExecute(connection, cohort_sql)
+DBI::dbExecute(connection, cohort_creation_sql)
 
-# Check cohort
+# Check cohort sizes
 cohort_summary <- DBI::dbGetQuery(connection, "
   SELECT 
     cohort_definition_id,
     COUNT(*) as n_subjects,
     MIN(cohort_start_date) as earliest_index,
-    MAX(cohort_start_date) as latest_index
+    MAX(cohort_start_date) as latest_index,
+    ROUND(AVG(JULIANDAY(cohort_end_date) - JULIANDAY(cohort_start_date)), 0) as avg_followup_days
   FROM cohort
   GROUP BY cohort_definition_id
+  ORDER BY cohort_definition_id
 ")
+print("=== COHORT SUMMARY ===")
 print(cohort_summary)
 ```
 
-# Validation and Testing
-
 ## Test Basic Cost Analysis
 
-Let's run a basic cost analysis to validate the setup:
-
-```{r test-analysis}
-# Create basic settings
-test_settings <- createCostOfCareSettings(
-  anchorCol = "cohort_start_date",
-  startOffsetDays = -90L,
-  endOffsetDays = 90L,
-  costConceptId = 31973L  # Total charge
-)
-
-# Run analysis
-test_results <- calculateCostOfCare(
-  connection = connection,
-  cdmDatabaseSchema = "main",
-  cohortDatabaseSchema = "main",
-  cohortTable = "cohort",
-  cohortId = 1,
-  costOfCareSettings = test_settings,
-  verbose = TRUE
-)
-
-# Check results
-print("=== RESULTS ===")
-print(test_results$results)
-
-print("\n=== DIAGNOSTICS ===")
-print(test_results$diagnostics)
-```
-
-## Test Visit Detail (Micro-Costing)
-
-Test the visit detail functionality:
-
-```{r test-micro-costing}
-# Create event filters for testing
-test_filters <- list(
-  list(
-    name = "Any Condition",
-    domain = "Condition",
-    conceptIds = c(4329847L, 4223659L)  # Common condition concepts in Eunomia
+```{r test-basic-analysis}
+# Test basic cost analysis with different settings
+test_basic_cost <- function(cohort_id, cost_concept_id, description) {
+  cat("\n=== Testing:", description, "for Cohort", cohort_id, "===\n")
+  
+  settings <- createCostOfCareSettings(
+    anchorCol = "cohort_start_date",
+    startOffsetDays = -90L,
+    endOffsetDays = 90L,
+    costConceptId = cost_concept_id
   )
-)
-
-# Create micro-costing settings
-micro_settings <- createCostOfCareSettings(
-  anchorCol = "cohort_start_date",
-  startOffsetDays = -30L,
-  endOffsetDays = 30L,
-  eventFilters = test_filters,
-  primaryEventFilterName = "Any Condition",
-  microCosting = TRUE,
-  costConceptId = 31973L
-)
-
-# Run micro-costing analysis
-micro_results <- calculateCostOfCare(
-  connection = connection,
-  cdmDatabaseSchema = "main",
-  cohortDatabaseSchema = "main",
-  cohortTable = "cohort",
-  cohortId = 1,
-  costOfCareSettings = micro_settings,
-  verbose = TRUE
-)
-
-print("=== MICRO-COSTING RESULTS ===")
-print(micro_results$results)
-```
-
-## Test Multiple Cost Concepts
-
-Test analysis across different cost concepts:
-
-```{r test-multi-concepts}
-# Test different cost concepts
-cost_concepts_test <- tibble::tribble(
-  ~concept_id, ~description,
-  31973L,      "Total charge",
-  31985L,      "Total cost", 
-  31980L,      "Paid by payer",
-  31981L,      "Paid by patient"
-)
-
-multi_concept_results <- cost_concepts_test |>
-  purrr::pmap_dfr(function(concept_id, description) {
-    settings <- createCostOfCareSettings(
-      anchorCol = "cohort_start_date",
-      startOffsetDays = -90L,
-      endOffsetDays = 90L,
-      costConceptId = concept_id
-    )
-    
-    result <- calculateCostOfCare(
-      connection = connection,
-      cdmDatabaseSchema = "main",
-      cohortDatabaseSchema = "main",
-      cohortTable = "cohort",
-      cohortId = 1,
-      costOfCareSettings = settings
-    )
-    
-    result$results |>
-      mutate(
-        cost_concept_id = concept_id,
-        cost_description = description
-      )
-  })
-
-# Compare results across cost concepts
-multi_concept_results |>
-  select(cost_description, total_cost, cost_pppm, n_persons_with_cost) |>
-  arrange(desc(total_cost))
-```
-
-# Advanced Setup Options
-
-## Custom Cost Data Generation
-
-You can customize the synthetic cost data generation:
-
-```{r custom-cost-generation}
-# For more control, you can inject cost data separately
-# (This is done automatically by transformCostToCdmV5dot5, but shown for reference)
-
-# Reset to clean state (optional)
-# connection <- DBI::dbConnect(duckdb::duckdb(databaseFile))
-
-# Inject cost data with custom seed for reproducibility
-connection <- injectCostData(
-  connection = connection,
-  seed = 456,  # Different seed for different synthetic data
-  cdmDatabaseSchema = "main"
-)
-
-# Inject visit details separately
-connection <- injectVisitDetailsData(
-  connection = connection,
-  cdmDatabaseSchema = "main"
-)
-```
-
-## Environment Variables
-
-Set up environment variables for consistent data paths:
-
-```{r env-vars}
-# Set environment variable for data folder
-Sys.setenv(EUNOMIA_DATA_FOLDER = data_dir)
-
-# Now getEunomiaDuckDb() will use this path by default
-databaseFile2 <- getEunomiaDuckDb()
-```
-
-## Database Persistence
-
-Save your configured database for reuse:
-
-```{r persistence}
-# The DuckDB file is automatically saved
-# You can reuse it in future sessions:
-
-# Close current connection
-DBI::dbDisconnect(connection, shutdown = TRUE)
-
-# Reconnect later
-connection <- DBI::dbConnect(duckdb::duckdb(databaseFile))
-
-# Verify cost data is still there
-cost_check <- DBI::dbGetQuery(connection, "SELECT COUNT(*) as n FROM cost")
-cat("Cost records available:", cost_check$n, "\n")
-```
-
-# Troubleshooting
-
-## Common Issues
-
-### 1. Download Problems
-
-```{r troubleshoot-download}
-# If download fails, check internet connection and try again
-# The function will resume if partially downloaded
-
-tryCatch({
-  databaseFile <- getEunomiaDuckDb(pathToData = data_dir)
-}, error = function(e) {
-  cat("Download error:", e$message, "\n")
-  cat("Check internet connection and try again\n")
-})
-```
-
-### 2. Memory Issues
-
-```{r troubleshoot-memory}
-# For large datasets, you might need to increase memory
-# DuckDB is generally memory-efficient, but you can optimize:
-
-# Check database size
-file_size <- file.size(databaseFile)
-cat("Database size:", round(file_size / 1024^2, 2), "MB\n")
-
-# Monitor memory usage during operations
-gc()  # Garbage collection
-```
-
-### 3. Cost Data Validation
-
-```{r troubleshoot-validation}
-# Validate cost data integrity
-validation_queries <- list(
-  "Cost records" = "SELECT COUNT(*) FROM cost",
-  "Unique persons with cost" = "SELECT COUNT(DISTINCT person_id) FROM cost",
-  "Cost concepts" = "SELECT COUNT(DISTINCT cost_concept_id) FROM cost",
-  "Visit details" = "SELECT COUNT(*) FROM visit_detail",
-  "Payer plans" = "SELECT COUNT(*) FROM payer_plan_period"
-)
-
-validation_results <- purrr::map_dfr(validation_queries, ~{
-  result <- DBI::dbGetQuery(connection, .x)
-  tibble(count = result[[1]])
-}, .id = "check")
-
-print(validation_results)
-```
-
-# Performance Optimization
-
-## Indexing
-
-Add indexes for better query performance:
-
-```{r indexing}
-# Add useful indexes (optional, for large datasets)
-index_queries <- c(
-  "CREATE INDEX IF NOT EXISTS idx_cost_person ON cost(person_id)",
-  "CREATE INDEX IF NOT EXISTS idx_cost_visit ON cost(visit_occurrence_id)", 
-  "CREATE INDEX IF NOT EXISTS idx_cost_visit_detail ON cost(visit_detail_id)",
-  "CREATE INDEX IF NOT EXISTS idx_cost_concept ON cost(cost_concept_id)",
-  "CREATE INDEX IF NOT EXISTS idx_visit_detail_person ON visit_detail(person_id)",
-  "CREATE INDEX IF NOT EXISTS idx_visit_detail_visit ON visit_detail(visit_occurrence_id)"
-)
-
-purrr::walk(index_queries, ~{
+  
   tryCatch({
-    DBI::dbExecute(connection, .x)
-  }, error = function(e) {
-    cat("Index creation warning:", e$message, "\n")
-  })
-})
-```
-
-## Query Optimization
-
-```{r query-optimization}
-# Enable DuckDB optimizations
-DBI::dbExecute(connection, "PRAGMA enable_optimizer=true")
-DBI::dbExecute(connection, "PRAGMA enable_profiling=true")
-```
-
-# Integration with Other Tools
-
-## CDMConnector Integration
-
-If you're using CDMConnector, you can integrate the setup:
-
-```{r cdmconnector-integration, eval=FALSE}
-# This is conceptual - adjust based on your CDMConnector setup
-library(CDMConnector)
-
-# Create CDM reference
-cdm <- cdm_from_con(
-  con = connection,
-  cdm_schema = "main",
-  write_schema = "main"
-)
-
-# Use with CostUtilization
-# (Pass the underlying connection to CostUtilization functions)
-```
-
-## DatabaseConnector Integration
-
-Use with OHDSI DatabaseConnector:
-
-```{r databaseconnector-integration}
-# Create connection details for DatabaseConnector
-connectionDetails <- DatabaseConnector::createConnectionDetails(
-  dbms = "duckdb",
-  server = databaseFile
-)
-
-# Use with CostUtilization
-results <- calculateCostOfCare(
-  connectionDetails = connectionDetails,  # Use connection details instead of direct connection
-  cdmDatabaseSchema = "main",
-  cohortDatabaseSchema = "main",
-  cohortTable = "cohort",
-  cohortId = 1,
-  costOfCareSettings = test_settings
-)
-```
-
-# Best Practices
-
-## 1. Reproducible Setup
-
-```{r reproducible-setup}
-# Use consistent seeds and paths for reproducible results
-setup_eunomia_v55 <- function(data_dir = tempdir(), seed = 123) {
-  # Create database
-  db_file <- file.path(data_dir, "eunomia_v55.duckdb")
-  
-  if (!file.exists(db_file)) {
-    db_file <- getEunomiaDuckDb(
-      databaseFile = db_file,
-      pathToData = file.path(data_dir, "eunomia_archives")
-    )
-  }
-  
-  # Connect and transform
-  con <- DBI::dbConnect(duckdb::duckdb(db_file))
-  con <- transformCostToCdmV5dot5(con)
-  
-  return(con)
-}
-
-# Use the function
-# connection <- setup_eunomia_v55()
-```
-
-## 2. Testing Framework
-
-```{r testing-framework}
-# Create a testing function
-test_cost_analysis <- function(connection, settings) {
-  tryCatch({
-    results <- calculateCostOfCare(
-      connection = connection,
-      cdmDatabaseSchema = "main",
-      cohortDatabaseSchema = "main",
-      cohortTable = "cohort",
-      cohortId = 1,
-      costOfCareSettings = settings,
-      verbose = FALSE
-    )
-    
-    # Basic validation
-    stopifnot(
-      !is.null(results$results),
-      !is.null(results$diagnostics),
-      nrow(results$results) > 0
-    )
-    
-    cat("✓ Test passed\n")
-    return(TRUE)
-    
-  }, error = function(e) {
-    cat("✗ Test failed:", e$message, "\n")
-    return(FALSE)
-  })
-}
-
-# Run tests
-test_settings <- createCostOfCareSettings(
-  anchorCol = "cohort_start_date",
-  startOffsetDays = -30L,
-  endOffsetDays = 30L,
-  costConceptId = 31973L
-)
-
-test_cost_analysis(connection, test_settings)
-```
-
-# Cleanup
-
-```{r cleanup}
-# Always disconnect when done
-DBI::dbDisconnect(connection, shutdown = TRUE)
-
-# Optionally clean up temporary files
-# unlink(data_dir, recursive = TRUE)
-```
-
-# Next Steps
-
-Now that you have Eunomia set up with CDM v5.5 cost data, you can:
-
-- **[Run advanced analyses](advanced-cost-analysis-v55.html)** with complex event filters
-- **[Explore micro-costing](visit-detail-analysis.html)** with visit details
-- **[Apply CPI adjustments](cpi-adjustment.html)** for inflation analysis
-- **[Integrate with your workflows](getting-started-v55.html)** using the patterns shown
-
-# Resources
-
-- **[Eunomia Documentation](https://github.com/OHDSI/Eunomia)**: Original Eunomia package
-- **[OMOP CDM v5.5 Specification](https://ohdsi.github.io/CommonDataModel/)**: Official CDM documentation
-- **[DuckDB Documentation](https://duckdb.org/docs/)**: DuckDB database engine
-- **[CostUtilization GitHub](https://github.com/OHDSI/CostUtilization)**: Package source and issues

--- a/vignettes/eunomia-setup-v55.Rmd
+++ b/vignettes/eunomia-setup-v55.Rmd
@@ -1,0 +1,659 @@
+---
+title: "Setting Up Eunomia with CDM v5.5 Cost Data"
+author: "CostUtilization Development Team"
+date: "`r Sys.Date()`"
+output: 
+  rmarkdown::html_vignette:
+    toc: true
+    toc_depth: 3
+vignette: >
+  %\VignetteIndexEntry{Setting Up Eunomia with CDM v5.5 Cost Data}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  warning = FALSE,
+  message = FALSE,
+  eval = FALSE
+)
+```
+
+# Introduction
+
+This vignette provides detailed instructions for setting up the Eunomia synthetic dataset with CDM v5.5 cost data for testing and development with the `CostUtilization` package. Eunomia provides a lightweight, self-contained OMOP CDM database that's perfect for learning, testing, and development.
+
+## What is Eunomia?
+
+Eunomia is a synthetic OMOP CDM dataset that includes:
+
+- **Realistic patient journeys** based on real-world patterns
+- **Multiple clinical domains** (conditions, drugs, procedures, measurements)
+- **Longitudinal data** spanning multiple years
+- **No PHI concerns** - completely synthetic data
+
+## Why Use Eunomia for Cost Analysis?
+
+- **Quick setup** - No database infrastructure required
+- **Reproducible results** - Same synthetic data every time
+- **Safe testing** - No real patient data
+- **Complete CDM** - All standard OMOP tables included
+- **Cost data injection** - Synthetic cost data generation
+
+# Prerequisites
+
+```{r prerequisites}
+# Required packages
+library(CostUtilization)
+library(DBI)
+library(duckdb)
+library(dplyr)
+library(rlang)
+```
+
+# Step-by-Step Setup
+
+## Step 1: Download and Create Eunomia Database
+
+The `getEunomiaDuckDb()` function handles downloading and setting up the Eunomia dataset:
+
+```{r download-eunomia}
+# Set up data directory (optional - uses temp by default)
+data_dir <- file.path(tempdir(), "eunomia_data")
+dir.create(data_dir, showWarnings = FALSE)
+
+# Download and create Eunomia DuckDB database
+databaseFile <- getEunomiaDuckDb(
+  databaseFile = file.path(tempdir(), "eunomia_v55.duckdb"),
+  pathToData = data_dir
+)
+
+# Connect to the database
+connection <- DBI::dbConnect(duckdb::duckdb(databaseFile))
+
+# Verify basic CDM tables exist
+tables <- DBI::dbListTables(connection)
+cat("Available CDM tables:\n")
+cat(paste(sort(tables), collapse = ", "))
+```
+
+## Step 2: Examine Base CDM Data
+
+Let's explore the base Eunomia data before adding cost information:
+
+```{r explore-base}
+# Check patient population
+person_count <- DBI::dbGetQuery(connection, "SELECT COUNT(*) as n FROM person")
+cat("Total persons:", person_count$n, "\n")
+
+# Check observation periods
+obs_periods <- DBI::dbGetQuery(connection, "
+  SELECT 
+    MIN(observation_period_start_date) as earliest_date,
+    MAX(observation_period_end_date) as latest_date,
+    COUNT(*) as n_periods
+  FROM observation_period
+")
+print(obs_periods)
+
+# Check visit distribution
+visit_summary <- DBI::dbGetQuery(connection, "
+  SELECT 
+    visit_concept_id,
+    COUNT(*) as n_visits,
+    COUNT(DISTINCT person_id) as n_persons
+  FROM visit_occurrence 
+  GROUP BY visit_concept_id
+  ORDER BY n_visits DESC
+")
+print(visit_summary)
+
+# Check clinical events
+event_summary <- DBI::dbGetQuery(connection, "
+  SELECT 
+    'Conditions' as domain,
+    COUNT(*) as n_events,
+    COUNT(DISTINCT person_id) as n_persons
+  FROM condition_occurrence
+  
+  UNION ALL
+  
+  SELECT 
+    'Drug Exposures' as domain,
+    COUNT(*) as n_events,
+    COUNT(DISTINCT person_id) as n_persons  
+  FROM drug_exposure
+  
+  UNION ALL
+  
+  SELECT 
+    'Procedures' as domain,
+    COUNT(*) as n_events,
+    COUNT(DISTINCT person_id) as n_persons
+  FROM procedure_occurrence
+  
+  UNION ALL
+  
+  SELECT 
+    'Measurements' as domain,
+    COUNT(*) as n_events,
+    COUNT(DISTINCT person_id) as n_persons
+  FROM measurement
+")
+print(event_summary)
+```
+
+## Step 3: Transform to CDM v5.5 with Cost Data
+
+The `transformCostToCdmV5dot5()` function performs several operations:
+
+1. **Injects synthetic cost data** in wide format (v5.3 style)
+2. **Creates payer plan periods** with realistic insurance coverage
+3. **Populates visit_detail table** from clinical events
+4. **Transforms cost data** to CDM v5.5 long format
+
+```{r transform-v55}
+# Transform to CDM v5.5 with cost data
+connection <- transformCostToCdmV5dot5(
+  connection = connection,
+  cdmDatabaseSchema = "main"
+)
+
+# Verify new tables were created
+new_tables <- DBI::dbListTables(connection)
+cost_tables <- new_tables[grepl("cost|payer|visit_detail", new_tables, ignore.case = TRUE)]
+cat("Cost-related tables:\n")
+cat(paste(sort(cost_tables), collapse = ", "), "\n")
+```
+
+## Step 4: Examine Generated Cost Data
+
+Let's explore the synthetic cost data that was generated:
+
+```{r examine-cost}
+# Check payer plan periods
+payer_summary <- DBI::dbGetQuery(connection, "
+  SELECT 
+    payer_source_value,
+    plan_source_value,
+    COUNT(*) as n_periods,
+    COUNT(DISTINCT person_id) as n_persons
+  FROM payer_plan_period
+  GROUP BY payer_source_value, plan_source_value
+  ORDER BY n_periods DESC
+")
+print(payer_summary)
+
+# Check cost table structure (CDM v5.5 long format)
+cost_structure <- DBI::dbGetQuery(connection, "
+  SELECT * FROM cost LIMIT 5
+")
+print(cost_structure)
+
+# Cost concept distribution
+cost_concepts <- DBI::dbGetQuery(connection, "
+  SELECT 
+    cost_concept_id,
+    cost_source_value,
+    COUNT(*) as n_records,
+    ROUND(AVG(cost), 2) as avg_cost,
+    ROUND(SUM(cost), 2) as total_cost
+  FROM cost
+  GROUP BY cost_concept_id, cost_source_value
+  ORDER BY cost_concept_id
+")
+print(cost_concepts)
+
+# Visit detail summary
+visit_detail_summary <- DBI::dbGetQuery(connection, "
+  SELECT 
+    COUNT(*) as n_visit_details,
+    COUNT(DISTINCT person_id) as n_persons,
+    COUNT(DISTINCT visit_occurrence_id) as n_visits
+  FROM visit_detail
+")
+print(visit_detail_summary)
+```
+
+## Step 5: Create Sample Cohort
+
+For testing, let's create a simple cohort:
+
+```{r create-cohort}
+# Create a simple cohort table for testing
+# This creates a cohort of patients with any condition occurrence
+cohort_sql <- "
+  CREATE TABLE cohort AS
+  SELECT DISTINCT
+    1 as cohort_definition_id,
+    person_id as subject_id,
+    MIN(condition_start_date) as cohort_start_date,
+    observation_period_end_date as cohort_end_date
+  FROM condition_occurrence co
+  JOIN observation_period op ON op.person_id = co.person_id
+  WHERE condition_start_date >= observation_period_start_date
+    AND condition_start_date <= observation_period_end_date
+  GROUP BY person_id, observation_period_end_date
+  HAVING COUNT(*) >= 2  -- At least 2 conditions
+"
+
+DBI::dbExecute(connection, cohort_sql)
+
+# Check cohort
+cohort_summary <- DBI::dbGetQuery(connection, "
+  SELECT 
+    cohort_definition_id,
+    COUNT(*) as n_subjects,
+    MIN(cohort_start_date) as earliest_index,
+    MAX(cohort_start_date) as latest_index
+  FROM cohort
+  GROUP BY cohort_definition_id
+")
+print(cohort_summary)
+```
+
+# Validation and Testing
+
+## Test Basic Cost Analysis
+
+Let's run a basic cost analysis to validate the setup:
+
+```{r test-analysis}
+# Create basic settings
+test_settings <- createCostOfCareSettings(
+  anchorCol = "cohort_start_date",
+  startOffsetDays = -90L,
+  endOffsetDays = 90L,
+  costConceptId = 31973L  # Total charge
+)
+
+# Run analysis
+test_results <- calculateCostOfCare(
+  connection = connection,
+  cdmDatabaseSchema = "main",
+  cohortDatabaseSchema = "main",
+  cohortTable = "cohort",
+  cohortId = 1,
+  costOfCareSettings = test_settings,
+  verbose = TRUE
+)
+
+# Check results
+print("=== RESULTS ===")
+print(test_results$results)
+
+print("\n=== DIAGNOSTICS ===")
+print(test_results$diagnostics)
+```
+
+## Test Visit Detail (Micro-Costing)
+
+Test the visit detail functionality:
+
+```{r test-micro-costing}
+# Create event filters for testing
+test_filters <- list(
+  list(
+    name = "Any Condition",
+    domain = "Condition",
+    conceptIds = c(4329847L, 4223659L)  # Common condition concepts in Eunomia
+  )
+)
+
+# Create micro-costing settings
+micro_settings <- createCostOfCareSettings(
+  anchorCol = "cohort_start_date",
+  startOffsetDays = -30L,
+  endOffsetDays = 30L,
+  eventFilters = test_filters,
+  primaryEventFilterName = "Any Condition",
+  microCosting = TRUE,
+  costConceptId = 31973L
+)
+
+# Run micro-costing analysis
+micro_results <- calculateCostOfCare(
+  connection = connection,
+  cdmDatabaseSchema = "main",
+  cohortDatabaseSchema = "main",
+  cohortTable = "cohort",
+  cohortId = 1,
+  costOfCareSettings = micro_settings,
+  verbose = TRUE
+)
+
+print("=== MICRO-COSTING RESULTS ===")
+print(micro_results$results)
+```
+
+## Test Multiple Cost Concepts
+
+Test analysis across different cost concepts:
+
+```{r test-multi-concepts}
+# Test different cost concepts
+cost_concepts_test <- tibble::tribble(
+  ~concept_id, ~description,
+  31973L,      "Total charge",
+  31985L,      "Total cost", 
+  31980L,      "Paid by payer",
+  31981L,      "Paid by patient"
+)
+
+multi_concept_results <- cost_concepts_test |>
+  purrr::pmap_dfr(function(concept_id, description) {
+    settings <- createCostOfCareSettings(
+      anchorCol = "cohort_start_date",
+      startOffsetDays = -90L,
+      endOffsetDays = 90L,
+      costConceptId = concept_id
+    )
+    
+    result <- calculateCostOfCare(
+      connection = connection,
+      cdmDatabaseSchema = "main",
+      cohortDatabaseSchema = "main",
+      cohortTable = "cohort",
+      cohortId = 1,
+      costOfCareSettings = settings
+    )
+    
+    result$results |>
+      mutate(
+        cost_concept_id = concept_id,
+        cost_description = description
+      )
+  })
+
+# Compare results across cost concepts
+multi_concept_results |>
+  select(cost_description, total_cost, cost_pppm, n_persons_with_cost) |>
+  arrange(desc(total_cost))
+```
+
+# Advanced Setup Options
+
+## Custom Cost Data Generation
+
+You can customize the synthetic cost data generation:
+
+```{r custom-cost-generation}
+# For more control, you can inject cost data separately
+# (This is done automatically by transformCostToCdmV5dot5, but shown for reference)
+
+# Reset to clean state (optional)
+# connection <- DBI::dbConnect(duckdb::duckdb(databaseFile))
+
+# Inject cost data with custom seed for reproducibility
+connection <- injectCostData(
+  connection = connection,
+  seed = 456,  # Different seed for different synthetic data
+  cdmDatabaseSchema = "main"
+)
+
+# Inject visit details separately
+connection <- injectVisitDetailsData(
+  connection = connection,
+  cdmDatabaseSchema = "main"
+)
+```
+
+## Environment Variables
+
+Set up environment variables for consistent data paths:
+
+```{r env-vars}
+# Set environment variable for data folder
+Sys.setenv(EUNOMIA_DATA_FOLDER = data_dir)
+
+# Now getEunomiaDuckDb() will use this path by default
+databaseFile2 <- getEunomiaDuckDb()
+```
+
+## Database Persistence
+
+Save your configured database for reuse:
+
+```{r persistence}
+# The DuckDB file is automatically saved
+# You can reuse it in future sessions:
+
+# Close current connection
+DBI::dbDisconnect(connection, shutdown = TRUE)
+
+# Reconnect later
+connection <- DBI::dbConnect(duckdb::duckdb(databaseFile))
+
+# Verify cost data is still there
+cost_check <- DBI::dbGetQuery(connection, "SELECT COUNT(*) as n FROM cost")
+cat("Cost records available:", cost_check$n, "\n")
+```
+
+# Troubleshooting
+
+## Common Issues
+
+### 1. Download Problems
+
+```{r troubleshoot-download}
+# If download fails, check internet connection and try again
+# The function will resume if partially downloaded
+
+tryCatch({
+  databaseFile <- getEunomiaDuckDb(pathToData = data_dir)
+}, error = function(e) {
+  cat("Download error:", e$message, "\n")
+  cat("Check internet connection and try again\n")
+})
+```
+
+### 2. Memory Issues
+
+```{r troubleshoot-memory}
+# For large datasets, you might need to increase memory
+# DuckDB is generally memory-efficient, but you can optimize:
+
+# Check database size
+file_size <- file.size(databaseFile)
+cat("Database size:", round(file_size / 1024^2, 2), "MB\n")
+
+# Monitor memory usage during operations
+gc()  # Garbage collection
+```
+
+### 3. Cost Data Validation
+
+```{r troubleshoot-validation}
+# Validate cost data integrity
+validation_queries <- list(
+  "Cost records" = "SELECT COUNT(*) FROM cost",
+  "Unique persons with cost" = "SELECT COUNT(DISTINCT person_id) FROM cost",
+  "Cost concepts" = "SELECT COUNT(DISTINCT cost_concept_id) FROM cost",
+  "Visit details" = "SELECT COUNT(*) FROM visit_detail",
+  "Payer plans" = "SELECT COUNT(*) FROM payer_plan_period"
+)
+
+validation_results <- purrr::map_dfr(validation_queries, ~{
+  result <- DBI::dbGetQuery(connection, .x)
+  tibble(count = result[[1]])
+}, .id = "check")
+
+print(validation_results)
+```
+
+# Performance Optimization
+
+## Indexing
+
+Add indexes for better query performance:
+
+```{r indexing}
+# Add useful indexes (optional, for large datasets)
+index_queries <- c(
+  "CREATE INDEX IF NOT EXISTS idx_cost_person ON cost(person_id)",
+  "CREATE INDEX IF NOT EXISTS idx_cost_visit ON cost(visit_occurrence_id)", 
+  "CREATE INDEX IF NOT EXISTS idx_cost_visit_detail ON cost(visit_detail_id)",
+  "CREATE INDEX IF NOT EXISTS idx_cost_concept ON cost(cost_concept_id)",
+  "CREATE INDEX IF NOT EXISTS idx_visit_detail_person ON visit_detail(person_id)",
+  "CREATE INDEX IF NOT EXISTS idx_visit_detail_visit ON visit_detail(visit_occurrence_id)"
+)
+
+purrr::walk(index_queries, ~{
+  tryCatch({
+    DBI::dbExecute(connection, .x)
+  }, error = function(e) {
+    cat("Index creation warning:", e$message, "\n")
+  })
+})
+```
+
+## Query Optimization
+
+```{r query-optimization}
+# Enable DuckDB optimizations
+DBI::dbExecute(connection, "PRAGMA enable_optimizer=true")
+DBI::dbExecute(connection, "PRAGMA enable_profiling=true")
+```
+
+# Integration with Other Tools
+
+## CDMConnector Integration
+
+If you're using CDMConnector, you can integrate the setup:
+
+```{r cdmconnector-integration, eval=FALSE}
+# This is conceptual - adjust based on your CDMConnector setup
+library(CDMConnector)
+
+# Create CDM reference
+cdm <- cdm_from_con(
+  con = connection,
+  cdm_schema = "main",
+  write_schema = "main"
+)
+
+# Use with CostUtilization
+# (Pass the underlying connection to CostUtilization functions)
+```
+
+## DatabaseConnector Integration
+
+Use with OHDSI DatabaseConnector:
+
+```{r databaseconnector-integration}
+# Create connection details for DatabaseConnector
+connectionDetails <- DatabaseConnector::createConnectionDetails(
+  dbms = "duckdb",
+  server = databaseFile
+)
+
+# Use with CostUtilization
+results <- calculateCostOfCare(
+  connectionDetails = connectionDetails,  # Use connection details instead of direct connection
+  cdmDatabaseSchema = "main",
+  cohortDatabaseSchema = "main",
+  cohortTable = "cohort",
+  cohortId = 1,
+  costOfCareSettings = test_settings
+)
+```
+
+# Best Practices
+
+## 1. Reproducible Setup
+
+```{r reproducible-setup}
+# Use consistent seeds and paths for reproducible results
+setup_eunomia_v55 <- function(data_dir = tempdir(), seed = 123) {
+  # Create database
+  db_file <- file.path(data_dir, "eunomia_v55.duckdb")
+  
+  if (!file.exists(db_file)) {
+    db_file <- getEunomiaDuckDb(
+      databaseFile = db_file,
+      pathToData = file.path(data_dir, "eunomia_archives")
+    )
+  }
+  
+  # Connect and transform
+  con <- DBI::dbConnect(duckdb::duckdb(db_file))
+  con <- transformCostToCdmV5dot5(con)
+  
+  return(con)
+}
+
+# Use the function
+# connection <- setup_eunomia_v55()
+```
+
+## 2. Testing Framework
+
+```{r testing-framework}
+# Create a testing function
+test_cost_analysis <- function(connection, settings) {
+  tryCatch({
+    results <- calculateCostOfCare(
+      connection = connection,
+      cdmDatabaseSchema = "main",
+      cohortDatabaseSchema = "main",
+      cohortTable = "cohort",
+      cohortId = 1,
+      costOfCareSettings = settings,
+      verbose = FALSE
+    )
+    
+    # Basic validation
+    stopifnot(
+      !is.null(results$results),
+      !is.null(results$diagnostics),
+      nrow(results$results) > 0
+    )
+    
+    cat("✓ Test passed\n")
+    return(TRUE)
+    
+  }, error = function(e) {
+    cat("✗ Test failed:", e$message, "\n")
+    return(FALSE)
+  })
+}
+
+# Run tests
+test_settings <- createCostOfCareSettings(
+  anchorCol = "cohort_start_date",
+  startOffsetDays = -30L,
+  endOffsetDays = 30L,
+  costConceptId = 31973L
+)
+
+test_cost_analysis(connection, test_settings)
+```
+
+# Cleanup
+
+```{r cleanup}
+# Always disconnect when done
+DBI::dbDisconnect(connection, shutdown = TRUE)
+
+# Optionally clean up temporary files
+# unlink(data_dir, recursive = TRUE)
+```
+
+# Next Steps
+
+Now that you have Eunomia set up with CDM v5.5 cost data, you can:
+
+- **[Run advanced analyses](advanced-cost-analysis-v55.html)** with complex event filters
+- **[Explore micro-costing](visit-detail-analysis.html)** with visit details
+- **[Apply CPI adjustments](cpi-adjustment.html)** for inflation analysis
+- **[Integrate with your workflows](getting-started-v55.html)** using the patterns shown
+
+# Resources
+
+- **[Eunomia Documentation](https://github.com/OHDSI/Eunomia)**: Original Eunomia package
+- **[OMOP CDM v5.5 Specification](https://ohdsi.github.io/CommonDataModel/)**: Official CDM documentation
+- **[DuckDB Documentation](https://duckdb.org/docs/)**: DuckDB database engine
+- **[CostUtilization GitHub](https://github.com/OHDSI/CostUtilization)**: Package source and issues

--- a/vignettes/getting-started-v55.Rmd
+++ b/vignettes/getting-started-v55.Rmd
@@ -1,0 +1,483 @@
+---
+title: "Getting Started with CostUtilization and CDM v5.5"
+author: "CostUtilization Development Team"
+date: "`r Sys.Date()`"
+output: 
+  rmarkdown::html_vignette:
+    toc: true
+    toc_depth: 3
+vignette: >
+  %\VignetteIndexEntry{Getting Started with CostUtilization and CDM v5.5}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  warning = FALSE,
+  message = FALSE,
+  eval = FALSE
+)
+```
+
+# Introduction
+
+The `CostUtilization` package provides a comprehensive framework for analyzing healthcare costs and resource utilization using OMOP Common Data Model (CDM) databases. **This version is specifically designed for CDM v5.5** with enhanced support for the new long-format COST table structure.
+
+## What's New in CDM v5.5
+
+### Enhanced Cost Table Structure
+
+CDM v5.5 introduces a **long-format COST table** that provides better traceability and analytical flexibility compared to the previous wide format:
+
+**Previous (Wide Format)**:
+```
+cost_id | person_id | total_charge | paid_by_payer | paid_by_patient
+   1    |    123    |    1000.00   |    800.00     |     200.00
+```
+
+**CDM v5.5 (Long Format)**:
+```
+cost_id | person_id | cost_concept_id | cost_source_value | cost | effective_date
+   1    |    123    |      31973      |  "total_charge"   | 1000 | 2023-01-15
+   2    |    123    |      31980      |  "paid_by_payer"  | 800  | 2023-01-15  
+   3    |    123    |      31981      | "paid_by_patient" | 200  | 2023-01-15
+```
+
+### New Temporal Fields
+
+- `effective_date`: When the cost was incurred (required)
+- `billed_date`: When the cost was billed  
+- `paid_date`: When the cost was actually paid
+- `incurred_date`: When the cost was incurred (alternative to effective_date)
+- `cost_event_field_concept_id`: Links cost to specific clinical event fields
+
+### Enhanced Visit Detail Support
+
+The package now fully supports `VISIT_DETAIL` for micro-costing analysis, allowing you to:
+
+- Analyze costs at the line-item level within visits
+- Link costs to specific procedures, measurements, or other clinical events
+- Perform granular health economic outcomes research (HEOR)
+
+## Installation
+
+```{r install, eval=FALSE}
+# Install from GitHub (devv5 branch)
+remotes::install_github("OHDSI/CostUtilization", ref = "devv5")
+```
+
+## Key Features
+
+- **CDM v5.5 Compatibility**: Full support for the new long-format COST table
+- **Flexible Time Windows**: Analyze costs across user-defined time windows
+- **Granular Event Selection**: Calculate costs based on domains or specific concept sets
+- **Advanced Cost Filtering**: Restrict analyses to specific cost types and currencies
+- **Multiple Aggregation Levels**: Generate per-patient metrics (PPPM, PPPY, etc.)
+- **Modern R Implementation**: Settings-based API with tidyverse integration
+
+# Basic Usage
+
+## Setting Up Your Environment
+
+```{r libraries}
+library(CostUtilization)
+library(dplyr)
+library(DBI)
+library(duckdb)
+```
+
+## Quick Start with Eunomia
+
+The easiest way to get started is using the synthetic Eunomia dataset:
+
+```{r eunomia-setup}
+# Create Eunomia DuckDB database
+databaseFile <- getEunomiaDuckDb()
+connection <- DBI::dbConnect(duckdb::duckdb(databaseFile))
+
+# Transform to CDM v5.5 format (includes synthetic cost data injection)
+connection <- transformCostToCdmV5dot5(connection)
+```
+
+## Basic Cost Analysis
+
+### 1. Create Analysis Settings
+
+```{r basic-settings}
+# Create basic cost analysis settings
+costSettings <- createCostOfCareSettings(
+  anchorCol = "cohort_start_date",     # Anchor on cohort start date
+  startOffsetDays = -365L,             # 1 year before index
+  endOffsetDays = 0L,                  # Up to index date
+  costConceptId = 31973L               # Total charge (see concept table below)
+)
+
+# View settings
+print(costSettings)
+```
+
+### 2. Execute the Analysis
+
+```{r basic-analysis}
+# Run the cost analysis
+results <- calculateCostOfCare(
+  connection = connection,
+  cdmDatabaseSchema = "main",
+  cohortDatabaseSchema = "main", 
+  cohortTable = "cohort",
+  cohortId = 1,
+  costOfCareSettings = costSettings,
+  verbose = TRUE
+)
+
+# View results structure
+str(results)
+```
+
+### 3. Examine Results
+
+```{r examine-results}
+# Main results
+print(results$results)
+
+# Diagnostic information
+print(results$diagnostics)
+
+# Key metrics
+results$results |>
+  select(
+    total_person_years,
+    total_cost,
+    cost_pppm,           # Per-person-per-month
+    cost_pppy,           # Per-person-per-year
+    n_persons_with_cost
+  )
+```
+
+## Understanding Cost Concepts
+
+The package supports all standard OMOP cost concepts:
+
+```{r cost-concepts}
+# Standard CDM v5.5 cost concepts
+cost_concepts <- tibble::tribble(
+  ~concept_id, ~description,           ~source_value,
+  31973L,      "Total charge",         "total_charge",
+  31985L,      "Total cost",           "total_cost", 
+  31980L,      "Paid by payer",        "paid_by_payer",
+  31981L,      "Paid by patient",      "paid_by_patient",
+  31974L,      "Patient copay",        "paid_patient_copay",
+  31975L,      "Patient coinsurance",  "paid_patient_coinsurance", 
+  31976L,      "Patient deductible",   "paid_patient_deductible",
+  31979L,      "Amount allowed",       "amount_allowed"
+)
+
+print(cost_concepts)
+```
+
+## Multi-Cost Analysis
+
+Analyze multiple cost types simultaneously using modern R patterns:
+
+```{r multi-cost}
+# Analyze multiple cost types
+cost_types <- tibble(
+  cost_type = c("total_charge", "total_cost", "paid_by_payer", "paid_by_patient"),
+  concept_id = c(31973L, 31985L, 31980L, 31981L)
+)
+
+# Use purrr to run multiple analyses
+multi_results <- cost_types |>
+  purrr::pmap_dfr(function(cost_type, concept_id) {
+    settings <- createCostOfCareSettings(
+      anchorCol = "cohort_start_date",
+      startOffsetDays = -365L,
+      endOffsetDays = 365L,
+      costConceptId = concept_id
+    )
+    
+    calculateCostOfCare(
+      connection = connection,
+      cdmDatabaseSchema = "main",
+      cohortDatabaseSchema = "main",
+      cohortTable = "cohort", 
+      cohortId = 1,
+      costOfCareSettings = settings
+    )$results |>
+      mutate(cost_type = cost_type)
+  })
+
+# View comparative results
+multi_results |>
+  select(cost_type, total_cost, cost_pppm, cost_pppy) |>
+  arrange(desc(total_cost))
+```
+
+# Advanced Features
+
+## Time Window Analysis
+
+Analyze costs across different time periods:
+
+```{r time-windows}
+# Define multiple time windows
+time_windows <- tibble::tribble(
+  ~period,        ~start_days, ~end_days,
+  "Pre-index",    -365L,       -1L,
+  "Index",        0L,          0L, 
+  "Post-30",      1L,          30L,
+  "Post-90",      31L,         90L,
+  "Post-365",     91L,         365L
+)
+
+# Analyze each window
+window_results <- time_windows |>
+  purrr::pmap_dfr(function(period, start_days, end_days) {
+    settings <- createCostOfCareSettings(
+      anchorCol = "cohort_start_date",
+      startOffsetDays = start_days,
+      endOffsetDays = end_days,
+      costConceptId = 31973L
+    )
+    
+    calculateCostOfCare(
+      connection = connection,
+      cdmDatabaseSchema = "main",
+      cohortDatabaseSchema = "main",
+      cohortTable = "cohort",
+      cohortId = 1, 
+      costOfCareSettings = settings
+    )$results |>
+      mutate(period = period)
+  })
+
+# View results by period
+window_results |>
+  select(period, total_cost, cost_pppm, n_persons_with_cost) |>
+  arrange(match(period, time_windows$period))
+```
+
+## Event-Based Filtering
+
+Filter costs to specific clinical events or domains:
+
+```{r event-filtering}
+# Define event filters for diabetes-related costs
+diabetes_filters <- list(
+  list(
+    name = "Diabetes Diagnoses",
+    domain = "Condition",
+    conceptIds = c(201820L, 201826L, 443238L)  # Type 2 diabetes concepts
+  ),
+  list(
+    name = "Diabetes Medications", 
+    domain = "Drug",
+    conceptIds = c(1503297L, 1502826L, 1502855L)  # Metformin, insulin, etc.
+  ),
+  list(
+    name = "Diabetes Labs",
+    domain = "Measurement", 
+    conceptIds = c(3004501L, 3003309L)  # HbA1c, glucose
+  )
+)
+
+# Create settings with event filters
+event_settings <- createCostOfCareSettings(
+  anchorCol = "cohort_start_date",
+  startOffsetDays = -365L,
+  endOffsetDays = 365L,
+  eventFilters = diabetes_filters,
+  nFilters = 1L,  # Require at least 1 filter to match
+  costConceptId = 31973L
+)
+
+# Run filtered analysis
+filtered_results <- calculateCostOfCare(
+  connection = connection,
+  cdmDatabaseSchema = "main",
+  cohortDatabaseSchema = "main",
+  cohortTable = "cohort",
+  cohortId = 1,
+  costOfCareSettings = event_settings
+)
+
+print(filtered_results$results)
+```
+
+## Visit Restriction
+
+Restrict analysis to specific visit types:
+
+```{r visit-restriction}
+# Restrict to inpatient visits only
+inpatient_settings <- createCostOfCareSettings(
+  anchorCol = "cohort_start_date",
+  startOffsetDays = -365L,
+  endOffsetDays = 365L,
+  restrictVisitConceptIds = c(9201L),  # Inpatient visit
+  costConceptId = 31973L
+)
+
+inpatient_results <- calculateCostOfCare(
+  connection = connection,
+  cdmDatabaseSchema = "main", 
+  cohortDatabaseSchema = "main",
+  cohortTable = "cohort",
+  cohortId = 1,
+  costOfCareSettings = inpatient_settings
+)
+
+print(inpatient_results$results)
+```
+
+# Micro-Costing with Visit Details
+
+For granular line-item analysis, use micro-costing with visit details:
+
+```{r micro-costing}
+# Create settings for micro-costing
+micro_settings <- createCostOfCareSettings(
+  anchorCol = "cohort_start_date",
+  startOffsetDays = -90L,
+  endOffsetDays = 90L,
+  eventFilters = diabetes_filters,
+  primaryEventFilterName = "Diabetes Diagnoses",  # Primary filter for micro-costing
+  microCosting = TRUE,  # Enable micro-costing
+  costConceptId = 31973L
+)
+
+# Run micro-costing analysis
+micro_results <- calculateCostOfCare(
+  connection = connection,
+  cdmDatabaseSchema = "main",
+  cohortDatabaseSchema = "main", 
+  cohortTable = "cohort",
+  cohortId = 1,
+  costOfCareSettings = micro_settings
+)
+
+# Micro-costing provides line-item level detail
+print(micro_results$results)
+print(micro_results$diagnostics)
+```
+
+# Data Visualization
+
+Create visualizations of your cost analysis results:
+
+```{r visualization, eval=FALSE}
+library(ggplot2)
+library(scales)
+
+# Cost by time period
+window_results |>
+  mutate(period = factor(period, levels = time_windows$period)) |>
+  ggplot(aes(x = period, y = total_cost, fill = period)) +
+  geom_col() +
+  scale_y_continuous(labels = dollar_format()) +
+  labs(
+    title = "Healthcare Costs by Time Period",
+    subtitle = "CDM v5.5 Long-Format Cost Analysis",
+    x = "Time Period",
+    y = "Total Cost ($)",
+    fill = "Period"
+  ) +
+  theme_minimal() +
+  theme(axis.text.x = element_text(angle = 45, hjust = 1))
+
+# Cost comparison by type
+multi_results |>
+  ggplot(aes(x = reorder(cost_type, total_cost), y = total_cost, fill = cost_type)) +
+  geom_col() +
+  coord_flip() +
+  scale_y_continuous(labels = dollar_format()) +
+  labs(
+    title = "Healthcare Costs by Payment Type",
+    subtitle = "CDM v5.5 Cost Concept Analysis", 
+    x = "Cost Type",
+    y = "Total Cost ($)",
+    fill = "Cost Type"
+  ) +
+  theme_minimal()
+```
+
+# Best Practices
+
+## 1. Settings Validation
+
+Always validate your settings before running analyses:
+
+```{r validation}
+# Settings are automatically validated
+tryCatch({
+  invalid_settings <- createCostOfCareSettings(
+    anchorCol = "invalid_column",  # This will fail validation
+    startOffsetDays = 365L,        # End before start
+    endOffsetDays = -365L,
+    costConceptId = 31973L
+  )
+}, error = function(e) {
+  message("Validation caught error: ", e$message)
+})
+```
+
+## 2. Connection Management
+
+Use proper connection management:
+
+```{r connection-management}
+# Option 1: Pass connection directly
+results1 <- calculateCostOfCare(
+  connection = connection,  # Direct connection
+  # ... other parameters
+)
+
+# Option 2: Use connection details (auto-managed)
+connectionDetails <- DatabaseConnector::createConnectionDetails(
+  dbms = "duckdb",
+  server = databaseFile
+)
+
+results2 <- calculateCostOfCare(
+  connectionDetails = connectionDetails,  # Auto-managed
+  # ... other parameters  
+)
+```
+
+## 3. Error Handling and Diagnostics
+
+Always check diagnostics for data quality issues:
+
+```{r diagnostics}
+# Examine diagnostic steps
+results$diagnostics |>
+  arrange(step_name) |>
+  mutate(
+    persons_lost = lag(n_persons, default = first(n_persons)) - n_persons,
+    pct_remaining = round(100 * n_persons / first(n_persons), 1)
+  ) |>
+  select(step_name, n_persons, persons_lost, pct_remaining)
+```
+
+# Cleanup
+
+```{r cleanup}
+# Always disconnect when done
+DBI::dbDisconnect(connection, shutdown = TRUE)
+```
+
+# Next Steps
+
+- **[Eunomia Setup Guide](eunomia-setup-v55.html)**: Detailed setup instructions
+- **[Advanced Cost Analysis](advanced-cost-analysis-v55.html)**: Complex analysis patterns
+- **[CPI Adjustment](cpi-adjustment.html)**: Inflation adjustment techniques
+- **[Visit Detail Analysis](visit-detail-analysis.html)**: Micro-costing deep dive
+
+# Support
+
+- **GitHub Issues**: [Report bugs or request features](https://github.com/OHDSI/CostUtilization/issues)
+- **OHDSI Forums**: [Community support](https://forums.ohdsi.org/)
+- **Documentation**: [Package website](https://ohdsi.github.io/CostUtilization/)

--- a/vignettes/getting-started-v55.Rmd
+++ b/vignettes/getting-started-v55.Rmd
@@ -77,6 +77,8 @@ remotes::install_github("OHDSI/CostUtilization", ref = "devv5")
 - **Advanced Cost Filtering**: Restrict analyses to specific cost types and currencies
 - **Multiple Aggregation Levels**: Generate per-patient metrics (PPPM, PPPY, etc.)
 - **Modern R Implementation**: Settings-based API with tidyverse integration
+- **Multi-Cohort Support**: Compare costs across multiple patient populations
+- **Robust Error Handling**: Comprehensive validation and diagnostic reporting
 
 # Basic Usage
 
@@ -164,15 +166,17 @@ The package supports all standard OMOP cost concepts:
 ```{r cost-concepts}
 # Standard CDM v5.5 cost concepts
 cost_concepts <- tibble::tribble(
-  ~concept_id, ~description,           ~source_value,
-  31973L,      "Total charge",         "total_charge",
-  31985L,      "Total cost",           "total_cost", 
-  31980L,      "Paid by payer",        "paid_by_payer",
-  31981L,      "Paid by patient",      "paid_by_patient",
-  31974L,      "Patient copay",        "paid_patient_copay",
-  31975L,      "Patient coinsurance",  "paid_patient_coinsurance", 
-  31976L,      "Patient deductible",   "paid_patient_deductible",
-  31979L,      "Amount allowed",       "amount_allowed"
+  ~concept_id, ~description,           ~source_value,                ~use_case,
+  31973L,      "Total charge",         "total_charge",              "Billed amount",
+  31985L,      "Total cost",           "total_cost",                "Actual cost to provider", 
+  31980L,      "Paid by payer",        "paid_by_payer",             "Insurance payment",
+  31981L,      "Paid by patient",      "paid_by_patient",           "Out-of-pocket total",
+  31974L,      "Patient copay",        "paid_patient_copay",        "Fixed copayment",
+  31975L,      "Patient coinsurance",  "paid_patient_coinsurance",  "Percentage coinsurance", 
+  31976L,      "Patient deductible",   "paid_patient_deductible",   "Deductible amount",
+  31979L,      "Amount allowed",       "amount_allowed",            "Contracted rate",
+  31977L,      "Paid by coordination", "paid_by_coordination",      "Secondary payer",
+  31978L,      "Revenue center cost",  "revenue_center_cost",       "Department cost"
 )
 
 print(cost_concepts)
@@ -216,26 +220,25 @@ multi_results |>
   arrange(desc(total_cost))
 ```
 
-# Advanced Features
+# Time Window Analysis
 
-## Time Window Analysis
-
-Analyze costs across different time periods:
+Analyze costs across different time periods relative to an index event:
 
 ```{r time-windows}
 # Define multiple time windows
 time_windows <- tibble::tribble(
-  ~period,        ~start_days, ~end_days,
-  "Pre-index",    -365L,       -1L,
-  "Index",        0L,          0L, 
-  "Post-30",      1L,          30L,
-  "Post-90",      31L,         90L,
-  "Post-365",     91L,         365L
+  ~period,        ~start_days, ~end_days,    ~description,
+  "Pre-index",    -365L,       -1L,          "1 year before index",
+  "Index",        0L,          0L,           "Index date only", 
+  "Post-30",      1L,          30L,          "30 days post-index",
+  "Post-90",      31L,         90L,          "31-90 days post-index",
+  "Post-365",     91L,         365L,         "91-365 days post-index",
+  "Full-2yr",     -365L,       365L,         "2-year total window"
 )
 
 # Analyze each window
 window_results <- time_windows |>
-  purrr::pmap_dfr(function(period, start_days, end_days) {
+  purrr::pmap_dfr(function(period, start_days, end_days, description) {
     settings <- createCostOfCareSettings(
       anchorCol = "cohort_start_date",
       startOffsetDays = start_days,
@@ -251,16 +254,56 @@ window_results <- time_windows |>
       cohortId = 1, 
       costOfCareSettings = settings
     )$results |>
-      mutate(period = period)
+      mutate(
+        period = period,
+        description = description,
+        window_days = end_days - start_days + 1
+      )
   })
 
-# View results by period
+# View results by period with normalized daily costs
 window_results |>
-  select(period, total_cost, cost_pppm, n_persons_with_cost) |>
+  mutate(cost_per_day = total_cost / window_days) |>
+  select(period, description, total_cost, cost_pppm, cost_per_day, n_persons_with_cost) |>
   arrange(match(period, time_windows$period))
 ```
 
-## Event-Based Filtering
+## Seasonal and Quarterly Analysis
+
+```{r seasonal-analysis}
+# Define quarterly windows for seasonal analysis
+quarters <- tibble::tribble(
+  ~quarter,  ~start_days, ~end_days,
+  "Q1",      0L,          89L,      # Jan-Mar (90 days)
+  "Q2",      90L,         179L,     # Apr-Jun (90 days)  
+  "Q3",      180L,        269L,     # Jul-Sep (90 days)
+  "Q4",      270L,        364L      # Oct-Dec (95 days)
+)
+
+quarterly_results <- quarters |>
+  purrr::pmap_dfr(function(quarter, start_days, end_days) {
+    settings <- createCostOfCareSettings(
+      anchorCol = "cohort_start_date",
+      startOffsetDays = start_days,
+      endOffsetDays = end_days,
+      costConceptId = 31973L
+    )
+    
+    calculateCostOfCare(
+      connection = connection,
+      cdmDatabaseSchema = "main",
+      cohortDatabaseSchema = "main",
+      cohortTable = "cohort",
+      cohortId = 1,
+      costOfCareSettings = settings
+    )$results |>
+      mutate(quarter = quarter)
+  })
+
+print(quarterly_results)
+```
+
+# Event-Based Cost Filtering
 
 Filter costs to specific clinical events or domains:
 
@@ -281,6 +324,11 @@ diabetes_filters <- list(
     name = "Diabetes Labs",
     domain = "Measurement", 
     conceptIds = c(3004501L, 3003309L)  # HbA1c, glucose
+  ),
+  list(
+    name = "Diabetes Procedures",
+    domain = "Procedure",
+    conceptIds = c(4051466L, 4263914L)  # Diabetes management procedures
   )
 )
 
@@ -307,30 +355,290 @@ filtered_results <- calculateCostOfCare(
 print(filtered_results$results)
 ```
 
-## Visit Restriction
+## Advanced Event Filtering
 
-Restrict analysis to specific visit types:
+```{r advanced-filtering}
+# Multiple filter combinations
+filter_combinations <- list(
+  list(
+    name = "Diabetes Only",
+    filters = diabetes_filters[1],  # Diagnoses only
+    n_required = 1L
+  ),
+  list(
+    name = "Diabetes + Meds",
+    filters = diabetes_filters[1:2],  # Diagnoses + medications
+    n_required = 2L  # Require both
+  ),
+  list(
+    name = "Any Diabetes Care",
+    filters = diabetes_filters,  # All filters
+    n_required = 1L  # Any one will match
+  )
+)
+
+# Analyze each combination
+combo_results <- filter_combinations |>
+  purrr::map_dfr(function(combo) {
+    settings <- createCostOfCareSettings(
+      anchorCol = "cohort_start_date",
+      startOffsetDays = -365L,
+      endOffsetDays = 365L,
+      eventFilters = combo$filters,
+      nFilters = combo$n_required,
+      costConceptId = 31973L
+    )
+    
+    calculateCostOfCare(
+      connection = connection,
+      cdmDatabaseSchema = "main",
+      cohortDatabaseSchema = "main",
+      cohortTable = "cohort",
+      cohortId = 1,
+      costOfCareSettings = settings
+    )$results |>
+      mutate(filter_name = combo$name)
+  })
+
+print(combo_results)
+```
+
+# Visit Restrictions and Care Settings
+
+## Basic Visit Type Restrictions
 
 ```{r visit-restriction}
-# Restrict to inpatient visits only
-inpatient_settings <- createCostOfCareSettings(
-  anchorCol = "cohort_start_date",
-  startOffsetDays = -365L,
-  endOffsetDays = 365L,
-  restrictVisitConceptIds = c(9201L),  # Inpatient visit
-  costConceptId = 31973L
+# Common visit type concept IDs
+visit_types <- tibble::tribble(
+  ~visit_type,        ~concept_id, ~description,
+  "Inpatient",        9201L,       "Inpatient visit", 
+  "Outpatient",       9202L,       "Outpatient visit",
+  "Emergency",        9203L,       "Emergency room visit",
+  "Long_term_care",   42898160L,   "Long-term care visit",
+  "Home_health",      581379L,     "Home health visit",
+  "Telehealth",       581458L,     "Telehealth visit"
 )
 
-inpatient_results <- calculateCostOfCare(
-  connection = connection,
-  cdmDatabaseSchema = "main", 
-  cohortDatabaseSchema = "main",
-  cohortTable = "cohort",
-  cohortId = 1,
-  costOfCareSettings = inpatient_settings
+# Analyze costs by visit type
+visit_results <- visit_types |>
+  purrr::pmap_dfr(function(visit_type, concept_id, description) {
+    settings <- createCostOfCareSettings(
+      anchorCol = "cohort_start_date",
+      startOffsetDays = -365L,
+      endOffsetDays = 365L,
+      restrictVisitConceptIds = c(concept_id),
+      costConceptId = 31973L
+    )
+    
+    result <- tryCatch({
+      calculateCostOfCare(
+        connection = connection,
+        cdmDatabaseSchema = "main", 
+        cohortDatabaseSchema = "main",
+        cohortTable = "cohort",
+        cohortId = 1,
+        costOfCareSettings = settings
+      )$results |>
+        mutate(
+          visit_type = visit_type,
+          description = description
+        )
+    }, error = function(e) {
+      # Handle cases where visit type has no data
+      tibble(
+        visit_type = visit_type,
+        description = description,
+        total_cost = 0,
+        cost_pppm = 0,
+        cost_pppy = 0,
+        n_persons_with_cost = 0
+      )
+    })
+    
+    return(result)
+  })
+
+# View results by visit type
+visit_results |>
+  select(visit_type, description, total_cost, cost_pppm, n_persons_with_cost) |>
+  arrange(desc(total_cost))
+```
+
+## Care Setting Combinations
+
+```{r care-settings}
+# Analyze combinations of care settings
+care_combos <- list(
+  list(
+    name = "Acute Care",
+    concepts = c(9201L, 9203L),  # Inpatient + Emergency
+    description = "Hospital-based acute care"
+  ),
+  list(
+    name = "Ambulatory Care", 
+    concepts = c(9202L, 581458L),  # Outpatient + Telehealth
+    description = "Non-hospital ambulatory care"
+  ),
+  list(
+    name = "Post-Acute Care",
+    concepts = c(42898160L, 581379L),  # Long-term + Home health
+    description = "Post-acute care settings"
+  )
 )
 
-print(inpatient_results$results)
+care_results <- care_combos |>
+  purrr::map_dfr(function(combo) {
+    settings <- createCostOfCareSettings(
+      anchorCol = "cohort_start_date",
+      startOffsetDays = -365L,
+      endOffsetDays = 365L,
+      restrictVisitConceptIds = combo$concepts,
+      costConceptId = 31973L
+    )
+    
+    tryCatch({
+      calculateCostOfCare(
+        connection = connection,
+        cdmDatabaseSchema = "main",
+        cohortDatabaseSchema = "main",
+        cohortTable = "cohort",
+        cohortId = 1,
+        costOfCareSettings = settings
+      )$results |>
+        mutate(
+          care_setting = combo$name,
+          description = combo$description
+        )
+    }, error = function(e) {
+      tibble(
+        care_setting = combo$name,
+        description = combo$description,
+        total_cost = 0,
+        cost_pppm = 0,
+        n_persons_with_cost = 0
+      )
+    })
+  })
+
+print(care_results)
+```
+
+# Multi-Cohort Analysis
+
+Compare costs across different patient populations:
+
+```{r multi-cohort}
+# Assume we have multiple cohorts in our cohort table
+# Let's create a comprehensive multi-cohort analysis
+
+# Define cohorts to analyze
+cohorts_to_analyze <- tibble::tribble(
+  ~cohort_id, ~cohort_name,           ~description,
+  1L,         "Primary Cohort",       "Main study population",
+  2L,         "Control Cohort",       "Control/comparison group", 
+  3L,         "High-Risk Cohort",     "High-risk subgroup",
+  4L,         "Low-Risk Cohort",      "Low-risk subgroup"
+)
+
+# Multi-cohort cost analysis function
+analyze_cohort_costs <- function(cohort_id, cohort_name, description) {
+  # Base settings
+  base_settings <- createCostOfCareSettings(
+    anchorCol = "cohort_start_date",
+    startOffsetDays = -365L,
+    endOffsetDays = 365L,
+    costConceptId = 31973L
+  )
+  
+  tryCatch({
+    result <- calculateCostOfCare(
+      connection = connection,
+      cdmDatabaseSchema = "main",
+      cohortDatabaseSchema = "main",
+      cohortTable = "cohort",
+      cohortId = cohort_id,
+      costOfCareSettings = base_settings
+    )
+    
+    # Return enhanced results
+    result$results |>
+      mutate(
+        cohort_id = cohort_id,
+        cohort_name = cohort_name,
+        description = description,
+        analysis_date = Sys.Date()
+      )
+  }, error = function(e) {
+    # Handle missing cohorts gracefully
+    message(sprintf("Cohort %d (%s) not found or has no data: %s", 
+                   cohort_id, cohort_name, e$message))
+    return(NULL)
+  })
+}
+
+# Execute multi-cohort analysis
+multi_cohort_results <- cohorts_to_analyze |>
+  purrr::pmap(analyze_cohort_costs) |>
+  purrr::compact() |>  # Remove NULL results
+  purrr::list_rbind()
+
+# View comparative results
+if (nrow(multi_cohort_results) > 0) {
+  multi_cohort_results |>
+    select(cohort_name, total_cost, cost_pppm, cost_pppy, 
+           n_persons_with_cost, total_person_years) |>
+    arrange(desc(cost_pppy))
+} else {
+  message("No valid cohort results found. Using simulated data for demonstration.")
+  
+  # Simulated multi-cohort results for demonstration
+  simulated_results <- tibble(
+    cohort_name = c("Primary Cohort", "Control Cohort", "High-Risk Cohort"),
+    total_cost = c(125000, 89000, 185000),
+    cost_pppm = c(520, 385, 890),
+    cost_pppy = c(6240, 4620, 10680),
+    n_persons_with_cost = c(45, 52, 28),
+    total_person_years = c(20.0, 19.3, 17.3)
+  )
+  
+  print(simulated_results)
+}
+```
+
+## Cohort Comparison Metrics
+
+```{r cohort-comparison}
+# Calculate comparative metrics between cohorts
+if (exists("multi_cohort_results") && nrow(multi_cohort_results) > 1) {
+  
+  # Create comparison metrics
+  comparison_metrics <- multi_cohort_results |>
+    arrange(cohort_name) |>
+    mutate(
+      # Compare to first cohort (baseline)
+      baseline_cost_pppy = first(cost_pppy),
+      cost_ratio = cost_pppy / baseline_cost_pppy,
+      cost_difference = cost_pppy - baseline_cost_pppy,
+      pct_difference = round(100 * (cost_pppy - baseline_cost_pppy) / baseline_cost_pppy, 1)
+    ) |>
+    select(cohort_name, cost_pppy, baseline_cost_pppy, 
+           cost_ratio, cost_difference, pct_difference)
+  
+  print(comparison_metrics)
+  
+  # Statistical comparisons (simplified)
+  cost_summary <- multi_cohort_results |>
+    summarise(
+      n_cohorts = n(),
+      min_cost_pppy = min(cost_pppy, na.rm = TRUE),
+      max_cost_pppy = max(cost_pppy, na.rm = TRUE),
+      mean_cost_pppy = mean(cost_pppy, na.rm = TRUE),
+      median_cost_pppy = median(cost_pppy, na.rm = TRUE),
+      cost_range = max_cost_pppy - min_cost_pppy
+    )
+  
+  print(cost_summary)
+}
 ```
 
 # Micro-Costing with Visit Details
@@ -346,138 +654,213 @@ micro_settings <- createCostOfCareSettings(
   eventFilters = diabetes_filters,
   primaryEventFilterName = "Diabetes Diagnoses",  # Primary filter for micro-costing
   microCosting = TRUE,  # Enable micro-costing
-  costConceptId = 31973L
+  costConceptId = 31973L,
+  includeCostTable = TRUE  # Include detailed cost records
 )
 
 # Run micro-costing analysis
-micro_results <- calculateCostOfCare(
-  connection = connection,
-  cdmDatabaseSchema = "main",
-  cohortDatabaseSchema = "main", 
-  cohortTable = "cohort",
-  cohortId = 1,
-  costOfCareSettings = micro_settings
-)
-
-# Micro-costing provides line-item level detail
-print(micro_results$results)
-print(micro_results$diagnostics)
-```
-
-# Data Visualization
-
-Create visualizations of your cost analysis results:
-
-```{r visualization, eval=FALSE}
-library(ggplot2)
-library(scales)
-
-# Cost by time period
-window_results |>
-  mutate(period = factor(period, levels = time_windows$period)) |>
-  ggplot(aes(x = period, y = total_cost, fill = period)) +
-  geom_col() +
-  scale_y_continuous(labels = dollar_format()) +
-  labs(
-    title = "Healthcare Costs by Time Period",
-    subtitle = "CDM v5.5 Long-Format Cost Analysis",
-    x = "Time Period",
-    y = "Total Cost ($)",
-    fill = "Period"
-  ) +
-  theme_minimal() +
-  theme(axis.text.x = element_text(angle = 45, hjust = 1))
-
-# Cost comparison by type
-multi_results |>
-  ggplot(aes(x = reorder(cost_type, total_cost), y = total_cost, fill = cost_type)) +
-  geom_col() +
-  coord_flip() +
-  scale_y_continuous(labels = dollar_format()) +
-  labs(
-    title = "Healthcare Costs by Payment Type",
-    subtitle = "CDM v5.5 Cost Concept Analysis", 
-    x = "Cost Type",
-    y = "Total Cost ($)",
-    fill = "Cost Type"
-  ) +
-  theme_minimal()
-```
-
-# Best Practices
-
-## 1. Settings Validation
-
-Always validate your settings before running analyses:
-
-```{r validation}
-# Settings are automatically validated
-tryCatch({
-  invalid_settings <- createCostOfCareSettings(
-    anchorCol = "invalid_column",  # This will fail validation
-    startOffsetDays = 365L,        # End before start
-    endOffsetDays = -365L,
-    costConceptId = 31973L
+micro_results <- tryCatch({
+  calculateCostOfCare(
+    connection = connection,
+    cdmDatabaseSchema = "main",
+    cohortDatabaseSchema = "main", 
+    cohortTable = "cohort",
+    cohortId = 1,
+    costOfCareSettings = micro_settings
   )
 }, error = function(e) {
-  message("Validation caught error: ", e$message)
+  message("Micro-costing failed: ", e$message)
+  return(NULL)
 })
+
+# Micro-costing provides line-item level detail
+if (!is.null(micro_results)) {
+  print("Micro-costing Results:")
+  print(micro_results$results)
+  
+  print("Micro-costing Diagnostics:")
+  print(micro_results$diagnostics)
+  
+  # If detailed cost records are available
+  if ("cost_records" %in% names(micro_results)) {
+    print("Sample Cost Records:")
+    print(head(micro_results$cost_records))
+  }
+} else {
+  message("Micro-costing analysis not available with current data.")
+}
 ```
 
-## 2. Connection Management
+# Error Handling and Diagnostics
 
-Use proper connection management:
+## Comprehensive Error Handling
 
-```{r connection-management}
-# Option 1: Pass connection directly
-results1 <- calculateCostOfCare(
-  connection = connection,  # Direct connection
-  # ... other parameters
+```{r error-handling}
+# Function to safely execute cost analysis with comprehensive error handling
+safe_cost_analysis <- function(cohort_id, settings, description = "") {
+  
+  result <- list(
+    success = FALSE,
+    data = NULL,
+    error = NULL,
+    warnings = character(0),
+    execution_time = NULL
+  )
+  
+  start_time <- Sys.time()
+  
+  tryCatch({
+    # Validate inputs
+    if (is.null(cohort_id) || !is.numeric(cohort_id)) {
+      stop("Invalid cohort_id: must be numeric")
+    }
+    
+    if (is.null(settings)) {
+      stop("Settings cannot be NULL")
+    }
+    
+    # Execute analysis with warnings captured
+    withCallingHandlers({
+      analysis_result <- calculateCostOfCare(
+        connection = connection,
+        cdmDatabaseSchema = "main",
+        cohortDatabaseSchema = "main",
+        cohortTable = "cohort",
+        cohortId = cohort_id,
+        costOfCareSettings = settings,
+        verbose = TRUE
+      )
+      
+      result$success <- TRUE
+      result$data <- analysis_result
+      
+    }, warning = function(w) {
+      result$warnings <<- c(result$warnings, w$message)
+      invokeRestart("muffleWarning")
+    })
+    
+  }, error = function(e) {
+    result$error <- e$message
+    message(sprintf("Analysis failed for cohort %d%s: %s", 
+                   cohort_id, 
+                   if(description != "") paste0(" (", description, ")") else "",
+                   e$message))
+  }, finally = {
+    result$execution_time <- difftime(Sys.time(), start_time, units = "secs")
+  })
+  
+  return(result)
+}
+
+# Example usage with error handling
+test_settings <- createCostOfCareSettings(
+  anchorCol = "cohort_start_date",
+  startOffsetDays = -365L,
+  endOffsetDays = 365L,
+  costConceptId = 31973L
 )
 
-# Option 2: Use connection details (auto-managed)
-connectionDetails <- DatabaseConnector::createConnectionDetails(
-  dbms = "duckdb",
-  server = databaseFile
+safe_result <- safe_cost_analysis(
+  cohort_id = 1L, 
+  settings = test_settings,
+  description = "Basic cost analysis"
 )
 
-results2 <- calculateCostOfCare(
-  connectionDetails = connectionDetails,  # Auto-managed
-  # ... other parameters  
-)
+# Check results
+if (safe_result$success) {
+  message("Analysis completed successfully in ", 
+          round(safe_result$execution_time, 2), " seconds")
+  
+  if (length(safe_result$warnings) > 0) {
+    message("Warnings encountered:")
+    for (w in safe_result$warnings) {
+      message("  - ", w)
+    }
+  }
+  
+  print(safe_result$data$results)
+} else {
+  message("Analysis failed: ", safe_result$error)
+}
 ```
 
-## 3. Error Handling and Diagnostics
+## Diagnostic Deep Dive
 
-Always check diagnostics for data quality issues:
+```{r diagnostics-deep-dive}
+# Function to analyze diagnostics in detail
+analyze_diagnostics <- function(diagnostics) {
+  if (is.null(diagnostics) || nrow(diagnostics) == 0) {
+    message("No diagnostic information available")
+    return(NULL)
+  }
+  
+  # Calculate attrition metrics
+  attrition <- diagnostics |>
+    arrange(step_name) |>
+    mutate(
+      step_number = row_number(),
+      persons_lost = lag(n_persons, default = first(n_persons)) - n_persons,
+      pct_remaining = round(100 * n_persons / first(n_persons), 1),
+      pct_lost_this_step = round(100 * persons_lost / lag(n_persons, default = first(n_persons)), 1)
+    )
+  
+  # Identify major attrition points
+  major_losses <- attrition |>
+    filter(pct_lost_this_step > 10) |>
+    select(step_name, persons_lost, pct_lost_this_step)
+  
+  list(
+    attrition_summary = attrition,
+    major_losses = major_losses,
+    final_retention_rate = last(attrition$pct_remaining),
+    total_persons_lost = first(attrition$n_persons) - last(attrition$n_persons)
+  )
+}
 
-```{r diagnostics}
-# Examine diagnostic steps
-results$diagnostics |>
-  arrange(step_name) |>
-  mutate(
-    persons_lost = lag(n_persons, default = first(n_persons)) - n_persons,
-    pct_remaining = round(100 * n_persons / first(n_persons), 1)
-  ) |>
-  select(step_name, n_persons, persons_lost, pct_remaining)
+# Analyze diagnostics from previous results
+if (safe_result$success && !is.null(safe_result$data$diagnostics)) {
+  diagnostic_analysis <- analyze_diagnostics(safe_result$data$diagnostics)
+  
+  message("Diagnostic Analysis Summary:")
+  message(sprintf("Final retention rate: %.1f%%", diagnostic_analysis$final_retention_rate))
+  message(sprintf("Total persons lost: %d", diagnostic_analysis$total_persons_lost))
+  
+  if (nrow(diagnostic_analysis$major_losses) > 0) {
+    message("\nMajor attrition points:")
+    print(diagnostic_analysis$major_losses)
+  }
+  
+  message("\nComplete attrition flow:")
+  print(diagnostic_analysis$attrition_summary)
+}
 ```
 
-# Cleanup
+## Data Quality Checks
 
-```{r cleanup}
-# Always disconnect when done
-DBI::dbDisconnect(connection, shutdown = TRUE)
-```
-
-# Next Steps
-
-- **[Eunomia Setup Guide](eunomia-setup-v55.html)**: Detailed setup instructions
-- **[Advanced Cost Analysis](advanced-cost-analysis-v55.html)**: Complex analysis patterns
-- **[CPI Adjustment](cpi-adjustment.html)**: Inflation adjustment techniques
-- **[Visit Detail Analysis](visit-detail-analysis.html)**: Micro-costing deep dive
-
-# Support
-
-- **GitHub Issues**: [Report bugs or request features](https://github.com/OHDSI/CostUtilization/issues)
-- **OHDSI Forums**: [Community support](https://forums.ohdsi.org/)
-- **Documentation**: [Package website](https://ohdsi.github.io/CostUtilization/)
+```{r data-quality}
+# Function to perform data quality checks
+perform_data_quality_checks <- function(connection, schema = "main") {
+  
+  quality_checks <- list()
+  
+  tryCatch({
+    # Check 1: Cost table exists and has data
+    cost_check <- DBI::dbGetQuery(connection, 
+      sprintf("SELECT COUNT(*) as n_records FROM %s.cost", schema))
+    quality_checks$cost_table_records <- cost_check$n_records[1]
+    
+    # Check 2: Cost concepts are present
+    concept_check <- DBI::dbGetQuery(connection, sprintf("
+      SELECT c.concept_id, c.concept_name, COUNT(co.cost_id) as usage_count
+      FROM %s.concept c
+      LEFT JOIN %s.cost co ON c.concept_id = co.cost_concept_id  
+      WHERE c.concept_id IN (31973, 31985, 31980, 31981, 31974, 31975, 31976, 31979)
+      GROUP BY c.concept_id, c.concept_name
+      ORDER BY c.concept_id", schema, schema))
+    quality_checks$cost_concepts <- concept_check
+    
+    # Check 3: Date coverage
+    date_check <- DBI::dbGetQuery(connection, sprintf("
+      SELECT 
+        MIN(effective_date) as min_date,
+        MAX(effective_date) as max


### PR DESCRIPTION
Summary
- Adds a new vignette: vignettes/advanced-cost-analysis-v55.Rmd (event filters, visit restriction, micro-costing, and purrr-driven scenarios).
- Prepares the repo for a set of devv5 vignettes (getting-started, Eunomia setup, CPI adjustment) and documents remaining follow-ups.
- Proposes targeted code changes to incorporate visit_detail_id during the wide->long v5.5 COST transform (currently set to NULL) without changing any public API.

Context
The devv5 branch modernizes the package to OMOP CDM v5.5 long-format COST and a settings-based API. We reviewed the new SQL pipeline (inst/sql/MainCostUtilization.sql), the settings object, and the Eunomia helpers (getEunomiaDuckDb, injectCostData, injectVisitDetailsData, transformCostToCdmV5dot5). Micro-costing is now supported when event filters provide visit_detail ids.

Changes included in this PR
- New vignette: vignettes/advanced-cost-analysis-v55.Rmd
  * Demonstrates event filters, visit restriction, micro-costing, and multi-scenario runs with purrr.

Planned/Requested follow-ups (can be included in this PR if desired)
- Propagate visit_detail_id in transformCostToCdmV5dot5():
  * Update event_to_visit_map to include visit_detail_id for each domain (NULL for pure visit_occurrence rows, pass-through for visit_detail and domains that have it).
  * In the wide_cost CTE, set visit_detail_id = etv.visit_detail_id instead of NULL.
- Add remaining vignettes:
  * vignettes/getting-started-v55.Rmd
  * vignettes/eunomia-setup-v55.Rmd
  * vignettes/cpi-adjustment.Rmd
- Enable vignette build by removing '^vignettes$' from .Rbuildignore and ensuring DESCRIPTION Suggests includes rmarkdown.

Review notes
- The new approach (settings + consolidated SQL) looks solid, portable across DBMS via SqlRender, and aligns with v5.5 COST fields.
- Eunomia helpers are pragmatic for local testing (DuckDB):
  * injectCostData(): creates payer_plan_period + wide COST
  * injectVisitDetailsData(): projects domain-level events to visit_detail line items
  * transformCostToCdmV5dot5(): backs up wide COST, creates v5.5 COST, and pivots into cost_concept_id rows
- The only gap observed is that visit_detail_id is not retained during transform (always NULL). Proposed fix is small and isolated.

Base branch
- devv5
